### PR TITLE
feat: items CRUD endpoints

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -223,6 +223,86 @@
           }
         }
       ]
+    },
+    {
+      "name": "Items",
+      "item": [
+        {
+          "name": "GET /items?search=",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/items?search=lamp",
+              "host": ["{{baseUrl}}"],
+              "path": ["items"],
+              "query": [
+                { "key": "search", "value": "lamp" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST /items",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"list_id\": \"<list-id>\",\n  \"name\": \"Vintage Lamp\",\n  \"description\": \"Brass floor lamp from the 1960s\",\n  \"quantity\": 1,\n  \"user_defined_value\": 85.00\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/items",
+              "host": ["{{baseUrl}}"],
+              "path": ["items"]
+            }
+          }
+        },
+        {
+          "name": "PATCH /items/:id",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Updated Lamp\",\n  \"quantity\": 2\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/items/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["items", ":id"],
+              "variable": [
+                { "key": "id", "value": "<item-id>" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "DELETE /items/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/items/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["items", ":id"],
+              "variable": [
+                { "key": "id", "value": "<item-id>" }
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,13 +69,12 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 | DELETE | /items/:id | Delete item |
 
 ```json
-// POST /items — request (multipart/form-data)
+// POST /items — request (application/json)
 {
   "list_id": "uuid",
   "name": "string",
-  "image": "<file>",         // optional, uploaded to S3/R2
   "description": "string",   // optional
-  "quantity": 1,
+  "quantity": 1,             // optional, min 1
   "location_id": "uuid",     // optional
   "user_defined_value": 0    // optional
 }
@@ -87,7 +86,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "description": "string",
   "quantity": 1,
   "user_defined_value": 0,
-  "images": [{ "id": "uuid", "url": "string" }],
+  "images": [],
   "created_at": "timestamp"
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 ---
 
-## Items <Badge type="danger" text="Not Implemented" />
+## Items <Badge type="tip" text="Implemented" />
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ hero:
 |---------|--------|
 | Auth (email + social) | <Badge type="warning" text="In Progress" /> |
 | Lists CRUD | <Badge type="tip" text="Implemented" /> |
-| Items CRUD | <Badge type="danger" text="Not Implemented" /> |
+| Items CRUD | <Badge type="tip" text="Implemented" /> |
 | Image upload + storage | <Badge type="danger" text="Not Implemented" /> |
 | AI image analysis | <Badge type="danger" text="Not Implemented" /> |
 | Dashboard + search | <Badge type="danger" text="Not Implemented" /> |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,9 +12,9 @@
 ## Milestone 2 — Lists + Items CRUD <Badge type="warning" text="In Progress" />
 
 - [x] Lists endpoints (GET, POST, PATCH, DELETE)
-- [ ] Items endpoints (GET, POST, PATCH, DELETE)
+- [x] Items endpoints (GET, POST, PATCH, DELETE)
 - [ ] Locations endpoints
-- [ ] Global item search (`GET /items?search=`)
+- [x] Global item search (`GET /items?search=`)
 
 ## Milestone 3 — Image Upload + Storage <Badge type="danger" text="Not Implemented" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "circulari",
+      "hasInstallScript": true,
       "dependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/config": "^4.0.0",

--- a/prisma/migrations/20260413000002_add_location/migration.sql
+++ b/prisma/migrations/20260413000002_add_location/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "locations" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "locations_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "items" ADD CONSTRAINT "items_location_id_fkey" FOREIGN KEY ("location_id") REFERENCES "locations"("id") ON UPDATE CASCADE ON DELETE SET NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,14 @@ model List {
   @@map("lists")
 }
 
+model Location {
+  id    String @id @default(uuid())
+  name  String
+  items Item[]
+
+  @@map("locations")
+}
+
 model Item {
   id                 String   @id @default(uuid())
   list_id            String
@@ -53,7 +61,8 @@ model Item {
   user_defined_value Decimal?
   created_at         DateTime @default(now()) @map("created_at")
 
-  list List @relation(fields: [list_id], references: [id], onDelete: Cascade)
+  list     List      @relation(fields: [list_id], references: [id], onDelete: Cascade)
+  location Location? @relation(fields: [location_id], references: [id])
 
   @@index([list_id])
   @@map("items")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { HealthModule } from './modules/health/health.module';
 import { PrismaModule } from './modules/prisma/prisma.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { ListsModule } from './modules/lists/lists.module';
+import { ItemsModule } from './modules/items/items.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { ListsModule } from './modules/lists/lists.module';
     HealthModule,
     AuthModule,
     ListsModule,
+    ItemsModule,
   ],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,9 @@ async function bootstrap() {
 
   app.enableShutdownHooks();
   app.setGlobalPrefix('api/v1');
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+  );
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port);

--- a/src/modules/items/dto/create-item.dto.ts
+++ b/src/modules/items/dto/create-item.dto.ts
@@ -28,4 +28,7 @@ export class CreateItemDto {
   @IsNumber()
   @IsOptional()
   user_defined_value?: number;
+
+  @IsOptional()
+  image?: unknown;
 }

--- a/src/modules/items/dto/create-item.dto.ts
+++ b/src/modules/items/dto/create-item.dto.ts
@@ -1,0 +1,28 @@
+import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+export class CreateItemDto {
+  @IsUUID()
+  @IsNotEmpty()
+  list_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  quantity?: number;
+
+  @IsUUID()
+  @IsOptional()
+  location_id?: string;
+
+  @IsNumber()
+  @IsOptional()
+  user_defined_value?: number;
+}

--- a/src/modules/items/dto/create-item.dto.ts
+++ b/src/modules/items/dto/create-item.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
 
 export class CreateItemDto {
@@ -13,6 +14,7 @@ export class CreateItemDto {
   @IsOptional()
   description?: string;
 
+  @Type(() => Number)
   @IsInt()
   @Min(1)
   @IsOptional()
@@ -22,6 +24,7 @@ export class CreateItemDto {
   @IsOptional()
   location_id?: string;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   user_defined_value?: number;

--- a/src/modules/items/dto/update-item.dto.ts
+++ b/src/modules/items/dto/update-item.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import { IsInt, IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
 
 export class UpdateItemDto {
@@ -9,6 +10,7 @@ export class UpdateItemDto {
   @IsOptional()
   description?: string;
 
+  @Type(() => Number)
   @IsInt()
   @Min(1)
   @IsOptional()
@@ -18,6 +20,7 @@ export class UpdateItemDto {
   @IsOptional()
   location_id?: string;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   user_defined_value?: number;

--- a/src/modules/items/dto/update-item.dto.ts
+++ b/src/modules/items/dto/update-item.dto.ts
@@ -1,0 +1,24 @@
+import { IsInt, IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+export class UpdateItemDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  quantity?: number;
+
+  @IsUUID()
+  @IsOptional()
+  location_id?: string;
+
+  @IsNumber()
+  @IsOptional()
+  user_defined_value?: number;
+}

--- a/src/modules/items/items.controller.spec.ts
+++ b/src/modules/items/items.controller.spec.ts
@@ -1,0 +1,110 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { ItemsController } from './items.controller';
+import { ItemsService } from './items.service';
+
+describe('ItemsController', () => {
+  let controller: ItemsController;
+
+  const mockItemsService = {
+    search: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ItemsController],
+      providers: [{ provide: ItemsService, useValue: mockItemsService }],
+    }).compile();
+
+    controller = module.get<ItemsController>(ItemsController);
+    jest.clearAllMocks();
+  });
+
+  const makeReq = (id: string) => ({ user: { id } }) as any;
+
+  describe('search', () => {
+    it('delegates to itemsService.search with userId and query', async () => {
+      const expected = [{ id: 'item-1', name: 'lamp' }];
+      mockItemsService.search.mockResolvedValue(expected);
+
+      const result = await controller.search('lamp', makeReq('user-1'));
+
+      expect(mockItemsService.search).toHaveBeenCalledWith('user-1', 'lamp');
+      expect(result).toBe(expected);
+    });
+
+    it('defaults query to empty string when not provided', async () => {
+      mockItemsService.search.mockResolvedValue([]);
+
+      await controller.search(undefined as any, makeReq('user-1'));
+
+      expect(mockItemsService.search).toHaveBeenCalledWith('user-1', '');
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ItemsController.prototype.search);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to itemsService.create with userId and dto', async () => {
+      const dto = { list_id: 'list-1', name: 'My Item' };
+      const expected = { id: 'item-1', name: 'My Item', images: [], created_at: new Date() };
+      mockItemsService.create.mockResolvedValue(expected);
+
+      const result = await controller.create(dto as any, makeReq('user-1'));
+
+      expect(mockItemsService.create).toHaveBeenCalledWith('user-1', dto);
+      expect(result).toBe(expected);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ItemsController.prototype.create);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to itemsService.update with id, userId, and dto', async () => {
+      const dto = { name: 'Updated' };
+      mockItemsService.update.mockResolvedValue(undefined);
+
+      await controller.update('item-1', dto as any, makeReq('user-1'));
+
+      expect(mockItemsService.update).toHaveBeenCalledWith('item-1', 'user-1', dto);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ItemsController.prototype.update);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates to itemsService.remove with id and userId', async () => {
+      mockItemsService.remove.mockResolvedValue(undefined);
+
+      await controller.remove('item-1', makeReq('user-1'));
+
+      expect(mockItemsService.remove).toHaveBeenCalledWith('item-1', 'user-1');
+    });
+
+    it('returns no body (undefined) for 204', async () => {
+      mockItemsService.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove('item-1', makeReq('user-1'));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ItemsController.prototype.remove);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/items/items.controller.ts
+++ b/src/modules/items/items.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { ItemsService } from './items.service';
+import { CreateItemDto } from './dto/create-item.dto';
+import { UpdateItemDto } from './dto/update-item.dto';
+
+@Controller('items')
+export class ItemsController {
+  constructor(private readonly itemsService: ItemsService) {}
+
+  @Get()
+  search(@Query('search') query: string = '', @Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.itemsService.search(user.id, query);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateItemDto, @Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.itemsService.create(user.id, dto);
+  }
+
+  @Patch(':id')
+  async update(@Param('id') id: string, @Body() dto: UpdateItemDto, @Req() req: Request) {
+    const user = req.user as { id: string };
+    await this.itemsService.update(id, user.id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string, @Req() req: Request) {
+    const user = req.user as { id: string };
+    await this.itemsService.remove(id, user.id);
+  }
+}

--- a/src/modules/items/items.module.ts
+++ b/src/modules/items/items.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ItemsController } from './items.controller';
 import { ItemsService } from './items.service';
 import { ItemsRepository } from './items.repository';
-import { ListsRepository } from '../lists/lists.repository';
+import { ListsModule } from '../lists/lists.module';
 
 @Module({
+  imports: [ListsModule],
   controllers: [ItemsController],
-  providers: [ItemsService, ItemsRepository, ListsRepository],
+  providers: [ItemsService, ItemsRepository],
 })
 export class ItemsModule {}

--- a/src/modules/items/items.module.ts
+++ b/src/modules/items/items.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ItemsController } from './items.controller';
+import { ItemsService } from './items.service';
+import { ItemsRepository } from './items.repository';
+import { ListsRepository } from '../lists/lists.repository';
+
+@Module({
+  controllers: [ItemsController],
+  providers: [ItemsService, ItemsRepository, ListsRepository],
+})
+export class ItemsModule {}

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -30,11 +30,11 @@ export class ItemsRepository {
     const result = await this.prisma.item.updateMany({
       where: { id, list: { user_id: userId } },
       data: {
-        ...(dto.name !== undefined && { name: dto.name }),
-        ...(dto.description !== undefined && { description: dto.description }),
-        ...(dto.quantity !== undefined && { quantity: dto.quantity }),
-        ...(dto.location_id !== undefined && { location_id: dto.location_id }),
-        ...(dto.user_defined_value !== undefined && {
+        ...(dto.name != null && { name: dto.name }),
+        ...(dto.description != null && { description: dto.description }),
+        ...(dto.quantity != null && { quantity: dto.quantity }),
+        ...(dto.location_id != null && { location_id: dto.location_id }),
+        ...(dto.user_defined_value != null && {
           user_defined_value: dto.user_defined_value,
         }),
       },

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateItemDto } from './dto/create-item.dto';
+import { UpdateItemDto } from './dto/update-item.dto';
+
+@Injectable()
+export class ItemsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(dto: CreateItemDto) {
+    return this.prisma.item.create({
+      data: {
+        list_id: dto.list_id,
+        name: dto.name,
+        description: dto.description,
+        quantity: dto.quantity ?? 1,
+        location_id: dto.location_id,
+        user_defined_value: dto.user_defined_value,
+      },
+    });
+  }
+
+  findOneOwnedByUser(id: string, userId: string) {
+    return this.prisma.item.findFirst({
+      where: { id, list: { user_id: userId } },
+    });
+  }
+
+  async update(id: string, userId: string, dto: UpdateItemDto) {
+    const result = await this.prisma.item.updateMany({
+      where: { id, list: { user_id: userId } },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.quantity !== undefined && { quantity: dto.quantity }),
+        ...(dto.location_id !== undefined && { location_id: dto.location_id }),
+        ...(dto.user_defined_value !== undefined && {
+          user_defined_value: dto.user_defined_value,
+        }),
+      },
+    });
+    return result.count;
+  }
+
+  async delete(id: string, userId: string) {
+    const result = await this.prisma.item.deleteMany({
+      where: { id, list: { user_id: userId } },
+    });
+    return result.count;
+  }
+
+  searchByUser(userId: string, search: string) {
+    return this.prisma.item.findMany({
+      where: {
+        list: { user_id: userId },
+        name: { contains: search, mode: 'insensitive' },
+      },
+      orderBy: { created_at: 'desc' },
+    });
+  }
+}

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -134,7 +134,8 @@ describe('ItemsService', () => {
   });
 
   describe('search', () => {
-    it('delegates to repository with userId and query', async () => {
+    it('delegates to repository with userId and query and returns mapped response', async () => {
+      const createdAt = new Date();
       const items = [
         {
           id: 'item-1',
@@ -144,7 +145,7 @@ describe('ItemsService', () => {
           quantity: 1,
           location_id: null,
           user_defined_value: null,
-          created_at: new Date(),
+          created_at: createdAt,
         },
       ];
       itemsRepository.searchByUser.mockResolvedValue(items);
@@ -152,7 +153,37 @@ describe('ItemsService', () => {
       const result = await service.search('user-1', 'lamp');
 
       expect(itemsRepository.searchByUser).toHaveBeenCalledWith('user-1', 'lamp');
-      expect(result).toBe(items);
+      expect(result).toEqual([
+        {
+          id: 'item-1',
+          name: 'vintage lamp',
+          description: null,
+          quantity: 1,
+          user_defined_value: null,
+          images: [],
+          created_at: createdAt,
+        },
+      ]);
+    });
+
+    it('converts user_defined_value Decimal to number in search results', async () => {
+      const createdAt = new Date();
+      itemsRepository.searchByUser.mockResolvedValue([
+        {
+          id: 'item-1',
+          list_id: 'list-1',
+          name: 'lamp',
+          description: null,
+          quantity: 1,
+          location_id: null,
+          user_defined_value: { valueOf: () => 5.5 } as any,
+          created_at: createdAt,
+        },
+      ]);
+
+      const result = await service.search('user-1', 'lamp');
+
+      expect(result[0].user_defined_value).toBe(5.5);
     });
 
     it('returns empty array when no items match', async () => {

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -1,0 +1,166 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ItemsService } from './items.service';
+import { ItemsRepository } from './items.repository';
+import { ListsRepository } from '../lists/lists.repository';
+
+describe('ItemsService', () => {
+  let service: ItemsService;
+  let itemsRepository: jest.Mocked<ItemsRepository>;
+  let listsRepository: jest.Mocked<ListsRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ItemsService,
+        {
+          provide: ItemsRepository,
+          useValue: {
+            create: jest.fn(),
+            findOneOwnedByUser: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+            searchByUser: jest.fn(),
+          },
+        },
+        {
+          provide: ListsRepository,
+          useValue: {
+            findOneByUser: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ItemsService>(ItemsService);
+    itemsRepository = module.get(ItemsRepository);
+    listsRepository = module.get(ListsRepository);
+  });
+
+  describe('create', () => {
+    const dto = { list_id: 'list-1', name: 'My Item' };
+    const mockItem = {
+      id: 'item-1',
+      list_id: 'list-1',
+      name: 'My Item',
+      description: null,
+      quantity: 1,
+      location_id: null,
+      user_defined_value: null,
+      created_at: new Date('2026-01-01'),
+    };
+
+    it('creates item when list belongs to caller', async () => {
+      listsRepository.findOneByUser.mockResolvedValue({
+        id: 'list-1',
+        user_id: 'user-1',
+        name: 'My List',
+        created_at: new Date(),
+      });
+      itemsRepository.create.mockResolvedValue(mockItem);
+
+      const result = await service.create('user-1', dto);
+
+      expect(listsRepository.findOneByUser).toHaveBeenCalledWith('list-1', 'user-1');
+      expect(itemsRepository.create).toHaveBeenCalledWith(dto);
+      expect(result).toEqual({
+        id: 'item-1',
+        name: 'My Item',
+        description: null,
+        quantity: 1,
+        user_defined_value: null,
+        images: [],
+        created_at: new Date('2026-01-01'),
+      });
+    });
+
+    it('throws NotFoundException when list does not belong to caller', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(null);
+
+      await expect(service.create('user-1', dto)).rejects.toThrow(NotFoundException);
+      expect(itemsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('converts user_defined_value Decimal to number in response', async () => {
+      listsRepository.findOneByUser.mockResolvedValue({
+        id: 'list-1',
+        user_id: 'user-1',
+        name: 'My List',
+        created_at: new Date(),
+      });
+      itemsRepository.create.mockResolvedValue({
+        ...mockItem,
+        user_defined_value: { valueOf: () => 9.99 } as any,
+      });
+
+      const result = await service.create('user-1', { ...dto, user_defined_value: 9.99 });
+
+      expect(result.user_defined_value).toBe(9.99);
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to repository when item is owned by user', async () => {
+      itemsRepository.update.mockResolvedValue(1);
+
+      await service.update('item-1', 'user-1', { name: 'Updated' });
+
+      expect(itemsRepository.update).toHaveBeenCalledWith('item-1', 'user-1', { name: 'Updated' });
+    });
+
+    it('throws NotFoundException when item not found or not owned', async () => {
+      itemsRepository.update.mockResolvedValue(0);
+
+      await expect(service.update('item-999', 'user-1', { name: 'x' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates to repository when item is owned by user', async () => {
+      itemsRepository.delete.mockResolvedValue(1);
+
+      await service.remove('item-1', 'user-1');
+
+      expect(itemsRepository.delete).toHaveBeenCalledWith('item-1', 'user-1');
+    });
+
+    it('throws NotFoundException when item not found or not owned', async () => {
+      itemsRepository.delete.mockResolvedValue(0);
+
+      await expect(service.remove('item-999', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('search', () => {
+    it('delegates to repository with userId and query', async () => {
+      const items = [
+        {
+          id: 'item-1',
+          list_id: 'list-1',
+          name: 'vintage lamp',
+          description: null,
+          quantity: 1,
+          location_id: null,
+          user_defined_value: null,
+          created_at: new Date(),
+        },
+      ];
+      itemsRepository.searchByUser.mockResolvedValue(items);
+
+      const result = await service.search('user-1', 'lamp');
+
+      expect(itemsRepository.searchByUser).toHaveBeenCalledWith('user-1', 'lamp');
+      expect(result).toBe(items);
+    });
+
+    it('returns empty array when no items match', async () => {
+      itemsRepository.searchByUser.mockResolvedValue([]);
+
+      const result = await service.search('user-1', 'nonexistent');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -22,7 +22,7 @@ export class ItemsService {
       name: item.name,
       description: item.description,
       quantity: item.quantity,
-      user_defined_value: item.user_defined_value ? Number(item.user_defined_value) : null,
+      user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
       images: [],
       created_at: item.created_at,
     };

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -42,7 +42,16 @@ export class ItemsService {
     }
   }
 
-  search(userId: string, query: string) {
-    return this.repository.searchByUser(userId, query);
+  async search(userId: string, query: string) {
+    const items = await this.repository.searchByUser(userId, query);
+    return items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      quantity: item.quantity,
+      user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
+      images: [],
+      created_at: item.created_at,
+    }));
   }
 }

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ItemsRepository } from './items.repository';
+import { ListsRepository } from '../lists/lists.repository';
+import { CreateItemDto } from './dto/create-item.dto';
+import { UpdateItemDto } from './dto/update-item.dto';
+
+@Injectable()
+export class ItemsService {
+  constructor(
+    private readonly repository: ItemsRepository,
+    private readonly listsRepository: ListsRepository,
+  ) {}
+
+  async create(userId: string, dto: CreateItemDto) {
+    const list = await this.listsRepository.findOneByUser(dto.list_id, userId);
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+    const item = await this.repository.create(dto);
+    return {
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      quantity: item.quantity,
+      user_defined_value: item.user_defined_value ? Number(item.user_defined_value) : null,
+      images: [],
+      created_at: item.created_at,
+    };
+  }
+
+  async update(id: string, userId: string, dto: UpdateItemDto) {
+    const count = await this.repository.update(id, userId, dto);
+    if (count === 0) {
+      throw new NotFoundException('Item not found');
+    }
+  }
+
+  async remove(id: string, userId: string) {
+    const count = await this.repository.delete(id, userId);
+    if (count === 0) {
+      throw new NotFoundException('Item not found');
+    }
+  }
+
+  search(userId: string, query: string) {
+    return this.repository.searchByUser(userId, query);
+  }
+}

--- a/src/modules/lists/lists.module.ts
+++ b/src/modules/lists/lists.module.ts
@@ -6,5 +6,6 @@ import { ListsRepository } from './lists.repository';
 @Module({
   controllers: [ListsController],
   providers: [ListsService, ListsRepository],
+  exports: [ListsRepository],
 })
 export class ListsModule {}

--- a/src/modules/lists/lists.repository.ts
+++ b/src/modules/lists/lists.repository.ts
@@ -36,6 +36,10 @@ export class ListsRepository {
     });
   }
 
+  findOneByUser(id: string, userId: string) {
+    return this.prisma.list.findFirst({ where: { id, user_id: userId } });
+  }
+
   async update(id: string, userId: string, name: string) {
     const result = await this.prisma.list.updateMany({
       where: { id, user_id: userId },


### PR DESCRIPTION
Closes #5

## What changed

- Added `GET /items?search=`, `POST /items`, `PATCH /items/:id`, and `DELETE /items/:id` endpoints with full JWT protection
- Implemented 3-layer NestJS module (Controller → Service → Repository) with cross-entity ownership check (item → list → user)
- Added `Location` model to Prisma schema with relation to `Item`; added `findOneByUser` to `ListsRepository` for list ownership verification
- Updated Postman collection, docs badges, and roadmap tasks

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (56 tests, all green)
- [ ] `POST /items` with valid `list_id` owned by caller → 201 with item shape
- [ ] `POST /items` with foreign `list_id` → 404
- [ ] `PATCH /items/:id` on own item → 200; foreign item → 404
- [ ] `DELETE /items/:id` on own item → 204; foreign item → 404
- [ ] `GET /items?search=lamp` returns only caller's items matching search
- [ ] Run `npx prisma migrate dev` after merge to apply Location table migration