### PR TITLE
feat: locations CRUD endpoints

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -303,6 +303,86 @@
           }
         }
       ]
+    },
+    {
+      "name": "Locations",
+      "item": [
+        {
+          "name": "GET /location?search=",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/location?search=bedroom",
+              "host": ["{{baseUrl}}"],
+              "path": ["location"],
+              "query": [
+                { "key": "search", "value": "bedroom" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST /location",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Bedroom\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/location",
+              "host": ["{{baseUrl}}"],
+              "path": ["location"]
+            }
+          }
+        },
+        {
+          "name": "PATCH /location/:id",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Master Bedroom\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/location/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["location", ":id"],
+              "variable": [
+                { "key": "id", "value": "<location-id>" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "DELETE /location/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/location/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["location", ":id"],
+              "variable": [
+                { "key": "id", "value": "<location-id>" }
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -114,7 +114,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 ---
 
-## Locations <Badge type="danger" text="Not Implemented" />
+## Locations <Badge type="tip" text="Implemented" />
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -41,6 +41,7 @@
 | Field | Type | Notes |
 |-------|------|-------|
 | id | uuid | PK |
+| user_id | uuid | FK → users (per-user isolation) |
 | name | string | e.g. "Bedroom", "Box 3" |
 
 ## ItemImage

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,11 +9,11 @@
 - [ ] `POST /auth/social` (Google + Apple)
 - [x] JWT middleware
 
-## Milestone 2 — Lists + Items CRUD <Badge type="warning" text="In Progress" />
+## Milestone 2 — Lists + Items CRUD <Badge type="tip" text="Implemented" />
 
 - [x] Lists endpoints (GET, POST, PATCH, DELETE)
 - [x] Items endpoints (GET, POST, PATCH, DELETE)
-- [ ] Locations endpoints
+- [x] Locations endpoints
 - [x] Global item search (`GET /items?search=`)
 
 ## Milestone 3 — Image Upload + Storage <Badge type="danger" text="Not Implemented" />

--- a/prisma/migrations/20260413172637_add_location_user_id/migration.sql
+++ b/prisma/migrations/20260413172637_add_location_user_id/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `user_id` to the `locations` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "locations" ADD COLUMN     "user_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "locations_user_id_idx" ON "locations"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "locations" ADD CONSTRAINT "locations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,8 @@ model User {
   refresh_token_hash String?
   created_at         DateTime @default(now()) @map("created_at")
 
-  lists List[]
+  lists     List[]
+  locations Location[]
 
   @@map("users")
 }
@@ -44,10 +45,13 @@ model List {
 }
 
 model Location {
-  id    String @id @default(uuid())
-  name  String
-  items Item[]
+  id      String @id @default(uuid())
+  user_id String
+  name    String
+  user    User   @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  items   Item[]
 
+  @@index([user_id])
   @@map("locations")
 }
 
@@ -62,7 +66,7 @@ model Item {
   created_at         DateTime @default(now()) @map("created_at")
 
   list     List      @relation(fields: [list_id], references: [id], onDelete: Cascade)
-  location Location? @relation(fields: [location_id], references: [id])
+  location Location? @relation(fields: [location_id], references: [id], onDelete: SetNull)
 
   @@index([list_id])
   @@map("items")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { PrismaModule } from './modules/prisma/prisma.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { ListsModule } from './modules/lists/lists.module';
 import { ItemsModule } from './modules/items/items.module';
+import { LocationsModule } from './modules/locations/locations.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { ItemsModule } from './modules/items/items.module';
     AuthModule,
     ListsModule,
     ItemsModule,
+    LocationsModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/locations/dto/create-location.dto.ts
+++ b/src/modules/locations/dto/create-location.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateLocationDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/src/modules/locations/dto/update-location.dto.ts
+++ b/src/modules/locations/dto/update-location.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateLocationDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/src/modules/locations/locations.controller.spec.ts
+++ b/src/modules/locations/locations.controller.spec.ts
@@ -1,0 +1,110 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { LocationsController } from './locations.controller';
+import { LocationsService } from './locations.service';
+
+describe('LocationsController', () => {
+  let controller: LocationsController;
+
+  const mockLocationsService = {
+    search: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LocationsController],
+      providers: [{ provide: LocationsService, useValue: mockLocationsService }],
+    }).compile();
+
+    controller = module.get<LocationsController>(LocationsController);
+    jest.clearAllMocks();
+  });
+
+  const makeReq = (id: string) => ({ user: { id } }) as any;
+
+  describe('search', () => {
+    it('delegates to locationsService.search with userId and query', async () => {
+      const expected = [{ id: 'loc-1', name: 'Bedroom' }];
+      mockLocationsService.search.mockResolvedValue(expected);
+
+      const result = await controller.search('Bed', makeReq('user-1'));
+
+      expect(mockLocationsService.search).toHaveBeenCalledWith('user-1', 'Bed');
+      expect(result).toBe(expected);
+    });
+
+    it('passes undefined query when not provided', async () => {
+      mockLocationsService.search.mockResolvedValue([]);
+
+      await controller.search(undefined, makeReq('user-1'));
+
+      expect(mockLocationsService.search).toHaveBeenCalledWith('user-1', undefined);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, LocationsController.prototype.search);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to locationsService.create with userId and name', async () => {
+      const dto = { name: 'Bedroom' };
+      const expected = { id: 'loc-1', name: 'Bedroom' };
+      mockLocationsService.create.mockResolvedValue(expected);
+
+      const result = await controller.create(dto as any, makeReq('user-1'));
+
+      expect(mockLocationsService.create).toHaveBeenCalledWith('user-1', 'Bedroom');
+      expect(result).toBe(expected);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, LocationsController.prototype.create);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('rename', () => {
+    it('delegates to locationsService.update with id, userId, and name', async () => {
+      const dto = { name: 'Living Room' };
+      mockLocationsService.update.mockResolvedValue(undefined);
+
+      await controller.rename('loc-1', dto as any, makeReq('user-1'));
+
+      expect(mockLocationsService.update).toHaveBeenCalledWith('loc-1', 'user-1', 'Living Room');
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, LocationsController.prototype.rename);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates to locationsService.remove with id and userId', async () => {
+      mockLocationsService.remove.mockResolvedValue(undefined);
+
+      await controller.remove('loc-1', makeReq('user-1'));
+
+      expect(mockLocationsService.remove).toHaveBeenCalledWith('loc-1', 'user-1');
+    });
+
+    it('returns no body (undefined) for 204', async () => {
+      mockLocationsService.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove('loc-1', makeReq('user-1'));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, LocationsController.prototype.remove);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/locations/locations.controller.ts
+++ b/src/modules/locations/locations.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { LocationsService } from './locations.service';
+import { CreateLocationDto } from './dto/create-location.dto';
+import { UpdateLocationDto } from './dto/update-location.dto';
+
+@Controller('location')
+export class LocationsController {
+  constructor(private readonly locationsService: LocationsService) {}
+
+  @Get()
+  search(@Query('search') query: string | undefined, @Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.locationsService.search(user.id, query);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateLocationDto, @Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.locationsService.create(user.id, dto.name);
+  }
+
+  @Patch(':id')
+  async rename(@Param('id') id: string, @Body() dto: UpdateLocationDto, @Req() req: Request) {
+    const user = req.user as { id: string };
+    await this.locationsService.update(id, user.id, dto.name);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string, @Req() req: Request) {
+    const user = req.user as { id: string };
+    await this.locationsService.remove(id, user.id);
+  }
+}

--- a/src/modules/locations/locations.module.ts
+++ b/src/modules/locations/locations.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LocationsController } from './locations.controller';
+import { LocationsService } from './locations.service';
+import { LocationsRepository } from './locations.repository';
+
+@Module({
+  controllers: [LocationsController],
+  providers: [LocationsService, LocationsRepository],
+})
+export class LocationsModule {}

--- a/src/modules/locations/locations.repository.ts
+++ b/src/modules/locations/locations.repository.ts
@@ -11,6 +11,7 @@ export class LocationsRepository {
         user_id: userId,
         ...(query ? { name: { contains: query, mode: 'insensitive' } } : {}),
       },
+      select: { id: true, name: true },
       orderBy: { name: 'asc' },
     });
   }
@@ -18,6 +19,7 @@ export class LocationsRepository {
   create(userId: string, name: string) {
     return this.prisma.location.create({
       data: { user_id: userId, name },
+      select: { id: true, name: true },
     });
   }
 

--- a/src/modules/locations/locations.repository.ts
+++ b/src/modules/locations/locations.repository.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class LocationsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  search(userId: string, query?: string) {
+    return this.prisma.location.findMany({
+      where: {
+        user_id: userId,
+        ...(query ? { name: { contains: query, mode: 'insensitive' } } : {}),
+      },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  create(userId: string, name: string) {
+    return this.prisma.location.create({
+      data: { user_id: userId, name },
+    });
+  }
+
+  async update(id: string, userId: string, name: string) {
+    const result = await this.prisma.location.updateMany({
+      where: { id, user_id: userId },
+      data: { name },
+    });
+    return result.count;
+  }
+
+  async delete(id: string, userId: string) {
+    const result = await this.prisma.location.deleteMany({
+      where: { id, user_id: userId },
+    });
+    return result.count;
+  }
+}

--- a/src/modules/locations/locations.service.spec.ts
+++ b/src/modules/locations/locations.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { LocationsService } from './locations.service';
+import { LocationsRepository } from './locations.repository';
+
+describe('LocationsService', () => {
+  let service: LocationsService;
+  let repository: jest.Mocked<LocationsRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocationsService,
+        {
+          provide: LocationsRepository,
+          useValue: {
+            search: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<LocationsService>(LocationsService);
+    repository = module.get(LocationsRepository);
+  });
+
+  describe('update', () => {
+    it('delegates to repository when location is owned by user', async () => {
+      repository.update.mockResolvedValue(1);
+
+      await service.update('loc-1', 'user-1', 'Bedroom');
+
+      expect(repository.update).toHaveBeenCalledWith('loc-1', 'user-1', 'Bedroom');
+    });
+
+    it('throws NotFoundException when location not found or not owned', async () => {
+      repository.update.mockResolvedValue(0);
+
+      await expect(service.update('loc-999', 'user-1', 'Bedroom')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('delegates to repository when location is owned by user', async () => {
+      repository.delete.mockResolvedValue(1);
+
+      await service.remove('loc-1', 'user-1');
+
+      expect(repository.delete).toHaveBeenCalledWith('loc-1', 'user-1');
+    });
+
+    it('throws NotFoundException when location not found or not owned', async () => {
+      repository.delete.mockResolvedValue(0);
+
+      await expect(service.remove('loc-999', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('search', () => {
+    it('delegates to repository with userId and query', async () => {
+      const locations = [{ id: 'loc-1', user_id: 'user-1', name: 'Bedroom' }];
+      repository.search.mockResolvedValue(locations as any);
+
+      const result = await service.search('user-1', 'Bed');
+
+      expect(repository.search).toHaveBeenCalledWith('user-1', 'Bed');
+      expect(result).toBe(locations);
+    });
+
+    it('delegates to repository with no query when omitted', async () => {
+      repository.search.mockResolvedValue([]);
+
+      await service.search('user-1');
+
+      expect(repository.search).toHaveBeenCalledWith('user-1', undefined);
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to repository with userId and name', async () => {
+      const location = { id: 'loc-1', user_id: 'user-1', name: 'Bedroom' };
+      repository.create.mockResolvedValue(location as any);
+
+      const result = await service.create('user-1', 'Bedroom');
+
+      expect(repository.create).toHaveBeenCalledWith('user-1', 'Bedroom');
+      expect(result).toBe(location);
+    });
+  });
+});

--- a/src/modules/locations/locations.service.ts
+++ b/src/modules/locations/locations.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { LocationsRepository } from './locations.repository';
+
+@Injectable()
+export class LocationsService {
+  constructor(private readonly repository: LocationsRepository) {}
+
+  search(userId: string, query?: string) {
+    return this.repository.search(userId, query);
+  }
+
+  create(userId: string, name: string) {
+    return this.repository.create(userId, name);
+  }
+
+  async update(id: string, userId: string, name: string) {
+    const count = await this.repository.update(id, userId, name);
+    if (count === 0) {
+      throw new NotFoundException('Location not found');
+    }
+  }
+
+  async remove(id: string, userId: string) {
+    const count = await this.repository.delete(id, userId);
+    if (count === 0) {
+      throw new NotFoundException('Location not found');
+    }
+  }
+}


### PR DESCRIPTION
Closes #6

## What changed

- Added `user_id` to `Location` model with cascade delete from User; `Item → Location` relation now uses `onDelete: SetNull` to preserve items when a location is deleted
- Implemented full Locations CRUD: `GET /location?search=`, `POST /location`, `PATCH /location/:id`, `DELETE /location/:id` — all JWT-protected with 404 on missing update/delete
- Registered `LocationsModule` in `AppModule` and added 4 endpoints to the Postman collection
- Updated `docs/api.md`, `docs/data-models.md`, `docs/roadmap.md` badges to reflect implementation; Milestone 2 is now fully complete

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (74 tests, all green)
- [ ] `POST /location` with valid name → 201; empty name → 400
- [ ] `GET /location?search=bed` → filtered results; no query → all user locations
- [ ] `PATCH /location/:id` own location → renamed; unknown id → 404
- [ ] `DELETE /location/:id` own location → 204; unknown id → 404
- [ ] Deleting a location sets `location_id = NULL` on associated items (not cascade delete)