### PR TITLE
feat: get items by list with cursor pagination

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -206,6 +206,27 @@
           }
         },
         {
+          "name": "GET /lists/:id/items",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/lists/:id/items?limit=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["lists", ":id", "items"],
+              "query": [
+                { "key": "cursor", "value": "", "description": "ID of the last item seen (omit for first page)" },
+                { "key": "limit", "value": "20", "description": "Page size (1–100, default 20)" }
+              ],
+              "variable": [
+                { "key": "id", "value": "<list-id>" }
+              ]
+            }
+          }
+        },
+        {
           "name": "DELETE /lists/:id",
           "request": {
             "method": "DELETE",

--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -217,7 +217,7 @@
               "host": ["{{baseUrl}}"],
               "path": ["lists", ":id", "items"],
               "query": [
-                { "key": "cursor", "value": "", "description": "ID of the last item seen (omit for first page)" },
+                { "key": "cursor", "value": "", "description": "ID of the last item seen (omit for first page)", "disabled": true },
                 { "key": "limit", "value": "20", "description": "Page size (1–100, default 20)" }
               ],
               "variable": [

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | /lists | All lists for authenticated user |
+| GET | /lists/:id/items | Paginated items for a specific list |
 | POST | /lists | Create list |
 | PATCH | /lists/:id | Rename list |
 | DELETE | /lists/:id | Delete list and all its items |
@@ -55,6 +56,29 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 // GET /lists — response 200
 [{ "id": "uuid", "name": "string", "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
+
+// GET /lists/:id/items — query params
+// cursor?: uuid   — ID of the last item seen (omit for first page)
+// limit?: number  — page size, 1–100 (default 20)
+
+// GET /lists/:id/items — response 200
+{
+  "data": [
+    {
+      "id": "uuid",
+      "name": "string",
+      "description": "string | null",
+      "quantity": 1,
+      "user_defined_value": 0,
+      "images": [],
+      "created_at": "timestamp"
+    }
+  ],
+  "nextCursor": "uuid | null"
+}
+
+// GET /lists/:id/items — errors
+// 404 — list not found or does not belong to the authenticated user
 ```
 
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,7 @@
 - [x] Items endpoints (GET, POST, PATCH, DELETE)
 - [x] Locations endpoints
 - [x] Global item search (`GET /items?search=`)
+- [x] Paginated items by list (`GET /lists/:id/items` — cursor-based)
 
 ## Milestone 3 — Image Upload + Storage <Badge type="warning" text="In Progress" />
 

--- a/src/modules/items/dto/get-items-by-list.dto.ts
+++ b/src/modules/items/dto/get-items-by-list.dto.ts
@@ -1,0 +1,15 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+
+export class GetItemsByListDto {
+  @IsUUID()
+  @IsOptional()
+  cursor?: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit?: number = 20;
+}

--- a/src/modules/items/items.module.ts
+++ b/src/modules/items/items.module.ts
@@ -1,12 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ItemsController } from './items.controller';
 import { ItemsService } from './items.service';
 import { ItemsRepository } from './items.repository';
 import { ListsModule } from '../lists/lists.module';
 
 @Module({
-  imports: [ListsModule],
+  imports: [forwardRef(() => ListsModule)],
   controllers: [ItemsController],
   providers: [ItemsService, ItemsRepository],
+  exports: [ItemsService],
 })
 export class ItemsModule {}

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -58,4 +58,14 @@ export class ItemsRepository {
       orderBy: { created_at: 'desc' },
     });
   }
+
+  findByList(listId: string, userId: string, cursor?: string, limit: number = 20) {
+    return this.prisma.item.findMany({
+      where: { list_id: listId, list: { user_id: userId } },
+      orderBy: { created_at: 'desc' },
+      take: limit + 1,
+      include: { location: true },
+      ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+    });
+  }
 }

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -62,9 +62,8 @@ export class ItemsRepository {
   findByList(listId: string, userId: string, cursor?: string, limit: number = 20) {
     return this.prisma.item.findMany({
       where: { list_id: listId, list: { user_id: userId } },
-      orderBy: { created_at: 'desc' },
+      orderBy: [{ created_at: 'desc' }, { id: 'desc' }],
       take: limit + 1,
-      include: { location: true },
       ...(cursor && { cursor: { id: cursor }, skip: 1 }),
     });
   }

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -21,6 +21,7 @@ describe('ItemsService', () => {
             update: jest.fn(),
             delete: jest.fn(),
             searchByUser: jest.fn(),
+            findByList: jest.fn(),
           },
         },
         {
@@ -192,6 +193,81 @@ describe('ItemsService', () => {
       const result = await service.search('user-1', 'nonexistent');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getByList', () => {
+    const mockList = { id: 'list-1', user_id: 'user-1', name: 'My List', created_at: new Date() };
+    const makeItem = (id: string, createdAt = new Date()) => ({
+      id,
+      list_id: 'list-1',
+      name: `Item ${id}`,
+      description: null,
+      quantity: 1,
+      location_id: null,
+      location: null,
+      user_defined_value: null,
+      created_at: createdAt,
+    });
+
+    it('throws NotFoundException when list does not belong to caller', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(null);
+
+      await expect(service.getByList('list-1', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(itemsRepository.findByList).not.toHaveBeenCalled();
+    });
+
+    it('returns first page with nextCursor set when more items exist', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      const rows = Array.from({ length: 21 }, (_, i) => makeItem(`item-${i}`));
+      itemsRepository.findByList.mockResolvedValue(rows);
+
+      const result = await service.getByList('list-1', 'user-1', undefined, 20);
+
+      expect(itemsRepository.findByList).toHaveBeenCalledWith('list-1', 'user-1', undefined, 20);
+      expect(result.data).toHaveLength(20);
+      expect(result.nextCursor).toBe('item-19');
+    });
+
+    it('returns last page with nextCursor null when no more items', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      const rows = [makeItem('item-1'), makeItem('item-2')];
+      itemsRepository.findByList.mockResolvedValue(rows);
+
+      const result = await service.getByList('list-1', 'user-1', 'cursor-id', 20);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('returns empty data with nextCursor null for empty list', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      itemsRepository.findByList.mockResolvedValue([]);
+
+      const result = await service.getByList('list-1', 'user-1');
+
+      expect(result.data).toEqual([]);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('passes cursor to repository when provided', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      itemsRepository.findByList.mockResolvedValue([makeItem('item-5')]);
+
+      await service.getByList('list-1', 'user-1', 'cursor-abc', 10);
+
+      expect(itemsRepository.findByList).toHaveBeenCalledWith('list-1', 'user-1', 'cursor-abc', 10);
+    });
+
+    it('converts user_defined_value Decimal to number', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      itemsRepository.findByList.mockResolvedValue([
+        { ...makeItem('item-1'), user_defined_value: { valueOf: () => 12.5 } as any },
+      ]);
+
+      const result = await service.getByList('list-1', 'user-1');
+
+      expect(result.data[0].user_defined_value).toBe(12.5);
     });
   });
 });

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -54,4 +54,30 @@ export class ItemsService {
       created_at: item.created_at,
     }));
   }
+
+  async getByList(listId: string, userId: string, cursor?: string, limit: number = 20) {
+    const list = await this.listsRepository.findOneByUser(listId, userId);
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+
+    const rows = await this.repository.findByList(listId, userId, cursor, limit);
+    const hasNextPage = rows.length > limit;
+    const items = hasNextPage ? rows.slice(0, limit) : rows;
+    const nextCursor = hasNextPage ? items[items.length - 1].id : null;
+
+    return {
+      data: items.map((item) => ({
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        quantity: item.quantity,
+        user_defined_value:
+          item.user_defined_value != null ? Number(item.user_defined_value) : null,
+        images: [],
+        created_at: item.created_at,
+      })),
+      nextCursor,
+    };
+  }
 }

--- a/src/modules/lists/lists.controller.spec.ts
+++ b/src/modules/lists/lists.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
 import { ListsController } from './lists.controller';
 import { ListsService } from './lists.service';
+import { ItemsService } from '../items/items.service';
 
 describe('ListsController', () => {
   let controller: ListsController;
@@ -14,10 +15,17 @@ describe('ListsController', () => {
     remove: jest.fn(),
   };
 
+  const mockItemsService = {
+    getByList: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ListsController],
-      providers: [{ provide: ListsService, useValue: mockListsService }],
+      providers: [
+        { provide: ListsService, useValue: mockListsService },
+        { provide: ItemsService, useValue: mockItemsService },
+      ],
     }).compile();
 
     controller = module.get<ListsController>(ListsController);
@@ -104,6 +112,41 @@ describe('ListsController', () => {
 
     it('is NOT marked @Public so JwtAuthGuard protects it', () => {
       const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ListsController.prototype.remove);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('getItems', () => {
+    it('delegates to itemsService.getByList with listId, userId, cursor, and limit', async () => {
+      const expected = { data: [], nextCursor: null };
+      mockItemsService.getByList.mockResolvedValue(expected);
+
+      const result = await controller.getItems(
+        'list-1',
+        { cursor: 'cursor-abc', limit: 10 },
+        makeReq('user-1'),
+      );
+
+      expect(mockItemsService.getByList).toHaveBeenCalledWith('list-1', 'user-1', 'cursor-abc', 10);
+      expect(result).toBe(expected);
+    });
+
+    it('delegates with undefined cursor and default limit when not provided', async () => {
+      const expected = { data: [], nextCursor: null };
+      mockItemsService.getByList.mockResolvedValue(expected);
+
+      await controller.getItems('list-1', {}, makeReq('user-1'));
+
+      expect(mockItemsService.getByList).toHaveBeenCalledWith(
+        'list-1',
+        'user-1',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ListsController.prototype.getItems);
       expect(isPublic).toBeUndefined();
     });
   });

--- a/src/modules/lists/lists.controller.ts
+++ b/src/modules/lists/lists.controller.ts
@@ -8,21 +8,33 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { ListsService } from './lists.service';
 import { CreateListDto } from './dto/create-list.dto';
 import { UpdateListDto } from './dto/update-list.dto';
+import { ItemsService } from '../items/items.service';
+import { GetItemsByListDto } from '../items/dto/get-items-by-list.dto';
 
 @Controller('lists')
 export class ListsController {
-  constructor(private readonly listsService: ListsService) {}
+  constructor(
+    private readonly listsService: ListsService,
+    private readonly itemsService: ItemsService,
+  ) {}
 
   @Get()
   getAll(@Req() req: Request) {
     const user = req.user as { id: string };
     return this.listsService.getAll(user.id);
+  }
+
+  @Get(':id/items')
+  getItems(@Param('id') id: string, @Query() query: GetItemsByListDto, @Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.itemsService.getByList(id, user.id, query.cursor, query.limit);
   }
 
   @Post()

--- a/src/modules/lists/lists.module.ts
+++ b/src/modules/lists/lists.module.ts
@@ -1,9 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ListsController } from './lists.controller';
 import { ListsService } from './lists.service';
 import { ListsRepository } from './lists.repository';
+import { ItemsModule } from '../items/items.module';
 
 @Module({
+  imports: [forwardRef(() => ItemsModule)],
   controllers: [ListsController],
   providers: [ListsService, ListsRepository],
   exports: [ListsRepository],


### PR DESCRIPTION
Closes #16

## What changed

- Added `GET /lists/:id/items` endpoint that returns paginated items for a list (sorted by `created_at DESC`)
- Implemented cursor-based pagination via `cursor` (item ID) and `limit` (default 20, max 100) query params — response shape is `{ data: Item[], nextCursor: string | null }`
- Used `forwardRef()` to resolve the circular module dependency between `ItemsModule` (which needs `ListsRepository`) and `ListsModule` (which now imports `ItemsModule` to inject `ItemsService` into `ListsController`)
- Added unit tests for `ItemsService.getByList` (5 cases) and `ListsController.getItems` (3 cases)

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (102 total)
- [ ] `GET /api/v1/lists/:id/items` returns items sorted newest-first
- [ ] Passing `cursor` + `limit` fetches the correct page; `nextCursor` is null on the last page
- [ ] Returns 404 for a list that doesn't exist or belongs to another user