### PR TITLE
fix: return updated object from PATCH endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,12 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 // POST /lists — request
 { "name": "string" }
 
+// PATCH /lists/:id — request
+{ "name": "string" }
+
+// PATCH /lists/:id — response 200
+{ "id": "uuid", "name": "string", "created_at": "timestamp" }
+
 // GET /lists — response 200
 [{ "id": "uuid", "name": "string", "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
 
@@ -113,6 +119,26 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "images": [],
   "created_at": "timestamp"
 }
+
+// PATCH /items/:id — request (all fields optional)
+{
+  "name": "string",
+  "description": "string",
+  "quantity": 1,
+  "location_id": "uuid",
+  "user_defined_value": 0
+}
+
+// PATCH /items/:id — response 200
+{
+  "id": "uuid",
+  "name": "string",
+  "description": "string | null",
+  "quantity": 1,
+  "user_defined_value": "number | null",
+  "images": [],
+  "created_at": "timestamp"
+}
 ```
 
 ---
@@ -150,4 +176,10 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 ```json
 // POST /location — request
 { "name": "string" }
+
+// PATCH /location/:id — request
+{ "name": "string" }
+
+// PATCH /location/:id — response 200
+{ "id": "uuid", "name": "string" }
 ```

--- a/src/modules/items/items.controller.ts
+++ b/src/modules/items/items.controller.ts
@@ -34,9 +34,9 @@ export class ItemsController {
   }
 
   @Patch(':id')
-  async update(@Param('id') id: string, @Body() dto: UpdateItemDto, @Req() req: Request) {
+  update(@Param('id') id: string, @Body() dto: UpdateItemDto, @Req() req: Request) {
     const user = req.user as { id: string };
-    await this.itemsService.update(id, user.id, dto);
+    return this.itemsService.update(id, user.id, dto);
   }
 
   @Delete(':id')

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -39,7 +39,8 @@ export class ItemsRepository {
         }),
       },
     });
-    return result.count;
+    if (result.count === 0) return null;
+    return this.prisma.item.findFirst({ where: { id } });
   }
 
   async delete(id: string, userId: string) {

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -101,16 +101,28 @@ describe('ItemsService', () => {
   });
 
   describe('update', () => {
-    it('delegates to repository when item is owned by user', async () => {
-      itemsRepository.update.mockResolvedValue(1);
+    const mockUpdatedItem = {
+      id: 'item-1',
+      list_id: 'list-1',
+      name: 'Updated',
+      description: null,
+      quantity: 1,
+      location_id: null,
+      user_defined_value: null,
+      created_at: new Date(),
+    };
 
-      await service.update('item-1', 'user-1', { name: 'Updated' });
+    it('returns the updated item when found', async () => {
+      itemsRepository.update.mockResolvedValue(mockUpdatedItem);
+
+      const result = await service.update('item-1', 'user-1', { name: 'Updated' });
 
       expect(itemsRepository.update).toHaveBeenCalledWith('item-1', 'user-1', { name: 'Updated' });
+      expect(result).toMatchObject({ id: 'item-1', name: 'Updated', images: [] });
     });
 
     it('throws NotFoundException when item not found or not owned', async () => {
-      itemsRepository.update.mockResolvedValue(0);
+      itemsRepository.update.mockResolvedValue(null);
 
       await expect(service.update('item-999', 'user-1', { name: 'x' })).rejects.toThrow(
         NotFoundException,

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -29,10 +29,19 @@ export class ItemsService {
   }
 
   async update(id: string, userId: string, dto: UpdateItemDto) {
-    const count = await this.repository.update(id, userId, dto);
-    if (count === 0) {
+    const item = await this.repository.update(id, userId, dto);
+    if (!item) {
       throw new NotFoundException('Item not found');
     }
+    return {
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      quantity: item.quantity,
+      user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
+      images: [],
+      created_at: item.created_at,
+    };
   }
 
   async remove(id: string, userId: string) {

--- a/src/modules/lists/lists.controller.ts
+++ b/src/modules/lists/lists.controller.ts
@@ -45,9 +45,9 @@ export class ListsController {
   }
 
   @Patch(':id')
-  async rename(@Req() req: Request, @Param('id') id: string, @Body() dto: UpdateListDto) {
+  rename(@Req() req: Request, @Param('id') id: string, @Body() dto: UpdateListDto) {
     const user = req.user as { id: string };
-    await this.listsService.rename(id, user.id, dto);
+    return this.listsService.rename(id, user.id, dto);
   }
 
   @Delete(':id')

--- a/src/modules/lists/lists.repository.ts
+++ b/src/modules/lists/lists.repository.ts
@@ -45,7 +45,8 @@ export class ListsRepository {
       where: { id, user_id: userId },
       data: { name },
     });
-    return result.count;
+    if (result.count === 0) return null;
+    return this.prisma.list.findUnique({ where: { id } });
   }
 
   async delete(id: string, userId: string) {

--- a/src/modules/lists/lists.service.spec.ts
+++ b/src/modules/lists/lists.service.spec.ts
@@ -98,16 +98,22 @@ describe('ListsService', () => {
   });
 
   describe('rename', () => {
-    it('delegates to repository when list exists', async () => {
-      repository.update.mockResolvedValue(1);
+    it('returns the updated list when found', async () => {
+      repository.update.mockResolvedValue({
+        id: 'list-1',
+        user_id: 'user-1',
+        name: 'Updated Name',
+        created_at: new Date('2026-01-01'),
+      });
 
-      await service.rename('list-1', 'user-1', { name: 'Updated Name' });
+      const result = await service.rename('list-1', 'user-1', { name: 'Updated Name' });
 
       expect(repository.update).toHaveBeenCalledWith('list-1', 'user-1', 'Updated Name');
+      expect(result).toMatchObject({ id: 'list-1', name: 'Updated Name' });
     });
 
     it('throws NotFoundException when list not found or not owned', async () => {
-      repository.update.mockResolvedValue(0);
+      repository.update.mockResolvedValue(null);
 
       await expect(service.rename('list-999', 'user-1', { name: 'x' })).rejects.toThrow(
         NotFoundException,

--- a/src/modules/lists/lists.service.ts
+++ b/src/modules/lists/lists.service.ts
@@ -30,10 +30,15 @@ export class ListsService {
   }
 
   async rename(id: string, userId: string, dto: UpdateListDto) {
-    const count = await this.repository.update(id, userId, dto.name);
-    if (count === 0) {
+    const list = await this.repository.update(id, userId, dto.name);
+    if (!list) {
       throw new NotFoundException('List not found');
     }
+    return {
+      id: list.id,
+      name: list.name,
+      created_at: list.created_at,
+    };
   }
 
   async remove(id: string, userId: string) {

--- a/src/modules/locations/locations.controller.ts
+++ b/src/modules/locations/locations.controller.ts
@@ -34,9 +34,9 @@ export class LocationsController {
   }
 
   @Patch(':id')
-  async rename(@Param('id') id: string, @Body() dto: UpdateLocationDto, @Req() req: Request) {
+  rename(@Param('id') id: string, @Body() dto: UpdateLocationDto, @Req() req: Request) {
     const user = req.user as { id: string };
-    await this.locationsService.update(id, user.id, dto.name);
+    return this.locationsService.update(id, user.id, dto.name);
   }
 
   @Delete(':id')

--- a/src/modules/locations/locations.repository.ts
+++ b/src/modules/locations/locations.repository.ts
@@ -28,7 +28,11 @@ export class LocationsRepository {
       where: { id, user_id: userId },
       data: { name },
     });
-    return result.count;
+    if (result.count === 0) return null;
+    return this.prisma.location.findUnique({
+      where: { id },
+      select: { id: true, name: true },
+    });
   }
 
   async delete(id: string, userId: string) {

--- a/src/modules/locations/locations.service.spec.ts
+++ b/src/modules/locations/locations.service.spec.ts
@@ -28,16 +28,17 @@ describe('LocationsService', () => {
   });
 
   describe('update', () => {
-    it('delegates to repository when location is owned by user', async () => {
-      repository.update.mockResolvedValue(1);
+    it('returns the updated location when found', async () => {
+      repository.update.mockResolvedValue({ id: 'loc-1', name: 'Bedroom' });
 
-      await service.update('loc-1', 'user-1', 'Bedroom');
+      const result = await service.update('loc-1', 'user-1', 'Bedroom');
 
       expect(repository.update).toHaveBeenCalledWith('loc-1', 'user-1', 'Bedroom');
+      expect(result).toEqual({ id: 'loc-1', name: 'Bedroom' });
     });
 
     it('throws NotFoundException when location not found or not owned', async () => {
-      repository.update.mockResolvedValue(0);
+      repository.update.mockResolvedValue(null);
 
       await expect(service.update('loc-999', 'user-1', 'Bedroom')).rejects.toThrow(
         NotFoundException,

--- a/src/modules/locations/locations.service.ts
+++ b/src/modules/locations/locations.service.ts
@@ -14,10 +14,11 @@ export class LocationsService {
   }
 
   async update(id: string, userId: string, name: string) {
-    const count = await this.repository.update(id, userId, name);
-    if (count === 0) {
+    const location = await this.repository.update(id, userId, name);
+    if (!location) {
       throw new NotFoundException('Location not found');
     }
+    return location;
   }
 
   async remove(id: string, userId: string) {


### PR DESCRIPTION
Closes #18

## What changed

- **Repositories** (`items`, `lists`, `locations`): changed `update()` from returning a count to returning the updated record (via `updateMany` + `findFirst`/`findUnique`) or `null` when not found
- **Services**: `update()`/`rename()` now map and return the updated object instead of returning void; 404 check changed from `count === 0` to `!record`
- **Controllers**: removed `async`/`await` from PATCH handlers; added `return` so NestJS serialises the response body
- **Tests**: updated service spec mocks from numeric counts to object/null return values; added assertions on the returned shape
- **Docs**: added PATCH request/response shapes to `docs/api.md` for all three resources

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (102 tests, 12 suites)
- [ ] Manual: `PATCH /items/:id` returns the updated item body
- [ ] Manual: `PATCH /lists/:id` returns the updated list body
- [ ] Manual: `PATCH /location/:id` returns the updated location body
- [ ] Manual: 404 is returned for a non-existent or unauthorized id