### PR TITLE
feat: add category to items with seeded categories table

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -303,7 +303,7 @@
                 {
                   "key": "limit",
                   "value": "20",
-                  "description": "Page size (1\u2013100, default 20)"
+                  "description": "Page size (1–100, default 20)"
                 }
               ],
               "variable": [
@@ -391,7 +391,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"list_id\": \"<list-id>\",\n  \"name\": \"Vintage Lamp\",\n  \"description\": \"Brass floor lamp from the 1960s\",\n  \"quantity\": 1,\n  \"user_defined_value\": 85.00\n}"
+              "raw": "{\n  \"list_id\": \"<list-id>\",\n  \"name\": \"Vintage Lamp\",\n  \"description\": \"Brass floor lamp from the 1960s\",\n  \"quantity\": 1,\n  \"user_defined_value\": 85.0,\n  \"category_id\": \"<category-id>\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/items",
@@ -420,7 +420,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated Lamp\",\n  \"quantity\": 2\n}"
+              "raw": "{\n  \"name\": \"Updated Lamp\",\n  \"quantity\": 2,\n  \"category_id\": \"<category-id>\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/items/:id",
@@ -490,7 +490,7 @@
                   "key": "image",
                   "type": "file",
                   "src": "/path/to/image.jpg",
-                  "description": "Image file to analyze (JPEG, PNG, WebP, GIF \u2014 max 10 MB)"
+                  "description": "Image file to analyze (JPEG, PNG, WebP, GIF — max 10 MB)"
                 }
               ]
             },

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
       "description": "string | null",
       "quantity": 1,
       "user_defined_value": 0,
+      "category": { "id": "uuid", "name": "string" },
       "images": [],
       "created_at": "timestamp"
     }
@@ -105,6 +106,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "name": "string",
   "description": "string",   // optional
   "quantity": 1,             // optional, min 1
+  "category_id": "uuid",     // optional
   "user_defined_value": 0    // optional
 }
 
@@ -115,6 +117,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "description": "string",
   "quantity": 1,
   "user_defined_value": 0,
+  "category": { "id": "uuid", "name": "string" },  // or null
   "images": [],
   "created_at": "timestamp"
 }
@@ -124,6 +127,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "name": "string",
   "description": "string",
   "quantity": 1,
+  "category_id": "uuid",
   "user_defined_value": 0
 }
 
@@ -134,10 +138,13 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "description": "string | null",
   "quantity": 1,
   "user_defined_value": "number | null",
+  "category": { "id": "uuid", "name": "string" },  // or null
   "images": [],
   "created_at": "timestamp"
 }
 ```
+
+> **Categories** are read-only reference data. Use `GET /categories` is not exposed — seed the DB with `npm run prisma:seed` to populate them. Use a seeded category's `id` as `category_id` in item requests.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,7 +76,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
       "description": "string | null",
       "quantity": 1,
       "user_defined_value": 0,
-      "category": { "id": "uuid", "name": "string" },
+      "category": { "id": "uuid", "name": "string" } | null,
       "images": [],
       "created_at": "timestamp"
     }
@@ -144,7 +144,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 }
 ```
 
-> **Categories** are read-only reference data. Use `GET /categories` is not exposed — seed the DB with `npm run prisma:seed` to populate them. Use a seeded category's `id` as `category_id` in item requests.
+> **Categories** are read-only reference data. No `GET /categories` endpoint is exposed — seed the DB with `npm run prisma:seed` to populate them. Use a seeded category's `id` as `category_id` in item requests.
 
 ---
 

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -33,8 +33,18 @@
 | name | string | AI-suggested or user-defined |
 | description | string | nullable |
 | quantity | integer | default 1 |
+| category_id | uuid | FK → categories, nullable; set to null when category deleted |
 | user_defined_value | decimal | user override; AI price used if null |
 | created_at | timestamp | |
+
+## Category
+
+Global reference data — seeded on `prisma:seed`, no CRUD endpoints exposed.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | uuid | PK |
+| name | string | unique; e.g. "Eletrônicos", "Roupas e Acessórios" |
 
 ## ItemImage
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,7 @@
 - [x] Refactor location from separate entity to plain `location` string on List
 - [x] Global item search (`GET /items?search=`)
 - [x] Paginated items by list (`GET /lists/:id/items` — cursor-based)
+- [x] Category reference table with seeded Portuguese values; `category_id` on items
 
 ## Milestone 3 — Image Upload + Storage <Badge type="warning" text="In Progress" />
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:cov": "jest --coverage",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "prisma:seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1030.0",

--- a/prisma/migrations/20260414235716_add_category/migration.sql
+++ b/prisma/migrations/20260414235716_add_category/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "items" ADD COLUMN     "category_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "items" ADD CONSTRAINT "items_category_id_fkey" FOREIGN KEY ("category_id") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260414235717_add_category_name_unique/migration.sql
+++ b/prisma/migrations/20260414235717_add_category_name_unique/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_name_key" ON "categories"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,16 +44,26 @@ model List {
   @@map("lists")
 }
 
+model Category {
+  id    String @id @default(uuid())
+  name  String @unique
+  items Item[]
+
+  @@map("categories")
+}
+
 model Item {
   id                 String   @id @default(uuid())
   list_id            String
   name               String
   description        String?
   quantity           Int      @default(1)
+  category_id        String?
   user_defined_value Decimal?
   created_at         DateTime @default(now()) @map("created_at")
 
-  list List @relation(fields: [list_id], references: [id], onDelete: Cascade)
+  list     List      @relation(fields: [list_id], references: [id], onDelete: Cascade)
+  category Category? @relation(fields: [category_id], references: [id], onDelete: SetNull)
 
   @@index([list_id])
   @@map("items")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '../src/generated/prisma';
+import { PrismaClient } from '../src/generated/prisma/client';
 
 const prisma = new PrismaClient();
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,34 @@
+import { PrismaClient } from '../src/generated/prisma';
+
+const prisma = new PrismaClient();
+
+const categories = [
+  'Eletrônicos',
+  'Roupas e Acessórios',
+  'Casa e Decoração',
+  'Livros e Mídia',
+  'Ferramentas',
+  'Esportes e Lazer',
+  'Saúde e Beleza',
+  'Brinquedos e Jogos',
+  'Alimentos e Bebidas',
+  'Outros',
+];
+
+async function main() {
+  for (const name of categories) {
+    await prisma.category.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+  console.log(`Seeded ${categories.length} categories.`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/modules/items/dto/create-item.dto.ts
+++ b/src/modules/items/dto/create-item.dto.ts
@@ -25,6 +25,10 @@ export class CreateItemDto {
   @IsOptional()
   user_defined_value?: number;
 
+  @IsUUID()
+  @IsOptional()
+  category_id?: string;
+
   @IsOptional()
   image?: unknown;
 }

--- a/src/modules/items/dto/update-item.dto.ts
+++ b/src/modules/items/dto/update-item.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsInt, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { IsInt, IsNumber, IsOptional, IsString, IsUUID, Min } from 'class-validator';
 
 export class UpdateItemDto {
   @IsString()
@@ -20,4 +20,8 @@ export class UpdateItemDto {
   @IsNumber()
   @IsOptional()
   user_defined_value?: number;
+
+  @IsUUID()
+  @IsOptional()
+  category_id?: string;
 }

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -35,7 +35,7 @@ export class ItemsRepository {
         ...(dto.name != null && { name: dto.name }),
         ...(dto.description != null && { description: dto.description }),
         ...(dto.quantity != null && { quantity: dto.quantity }),
-        ...(dto.category_id != null && { category_id: dto.category_id }),
+        ...(dto.category_id !== undefined && { category_id: dto.category_id }),
         ...(dto.user_defined_value != null && {
           user_defined_value: dto.user_defined_value,
         }),

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -14,14 +14,17 @@ export class ItemsRepository {
         name: dto.name,
         description: dto.description,
         quantity: dto.quantity ?? 1,
+        category_id: dto.category_id,
         user_defined_value: dto.user_defined_value,
       },
+      include: { category: true },
     });
   }
 
   findOneOwnedByUser(id: string, userId: string) {
     return this.prisma.item.findFirst({
       where: { id, list: { user_id: userId } },
+      include: { category: true },
     });
   }
 
@@ -32,13 +35,14 @@ export class ItemsRepository {
         ...(dto.name != null && { name: dto.name }),
         ...(dto.description != null && { description: dto.description }),
         ...(dto.quantity != null && { quantity: dto.quantity }),
+        ...(dto.category_id != null && { category_id: dto.category_id }),
         ...(dto.user_defined_value != null && {
           user_defined_value: dto.user_defined_value,
         }),
       },
     });
     if (result.count === 0) return null;
-    return this.prisma.item.findFirst({ where: { id } });
+    return this.prisma.item.findFirst({ where: { id }, include: { category: true } });
   }
 
   async delete(id: string, userId: string) {
@@ -55,6 +59,7 @@ export class ItemsRepository {
         name: { contains: search, mode: 'insensitive' },
       },
       orderBy: { created_at: 'desc' },
+      include: { category: true },
     });
   }
 
@@ -64,6 +69,7 @@ export class ItemsRepository {
       orderBy: [{ created_at: 'desc' }, { id: 'desc' }],
       take: limit + 1,
       ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+      include: { category: true },
     });
   }
 }

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ItemsService } from './items.service';
 import { ItemsRepository } from './items.repository';
 import { ListsRepository } from '../lists/lists.repository';
+import { Prisma } from '../../generated/prisma/client';
 
 describe('ItemsService', () => {
   let service: ItemsService;
@@ -86,7 +87,7 @@ describe('ItemsService', () => {
     });
 
     it('includes category object in response when category_id is provided', async () => {
-      const category = { id: 'cat-1', name: 'Eletrônicos' };
+      const category = { id: '00000000-0000-0000-0000-000000000001', name: 'Eletrônicos' };
       listsRepository.findOneByUser.mockResolvedValue({
         id: 'list-1',
         user_id: 'user-1',
@@ -94,9 +95,16 @@ describe('ItemsService', () => {
         location: null,
         created_at: new Date(),
       });
-      itemsRepository.create.mockResolvedValue({ ...mockItem, category_id: 'cat-1', category });
+      itemsRepository.create.mockResolvedValue({
+        ...mockItem,
+        category_id: '00000000-0000-0000-0000-000000000001',
+        category,
+      });
 
-      const result = await service.create('user-1', { ...dto, category_id: 'cat-1' });
+      const result = await service.create('user-1', {
+        ...dto,
+        category_id: '00000000-0000-0000-0000-000000000001',
+      });
 
       expect(result.category).toEqual(category);
     });
@@ -117,6 +125,25 @@ describe('ItemsService', () => {
       const result = await service.create('user-1', { ...dto, user_defined_value: 9.99 });
 
       expect(result.user_defined_value).toBe(9.99);
+    });
+
+    it('throws BadRequestException when category_id does not exist (P2003)', async () => {
+      listsRepository.findOneByUser.mockResolvedValue({
+        id: 'list-1',
+        user_id: 'user-1',
+        name: 'My List',
+        location: null,
+        created_at: new Date(),
+      });
+      const fkError = new Prisma.PrismaClientKnownRequestError('FK violation', {
+        code: 'P2003',
+        clientVersion: '0.0.0',
+      });
+      itemsRepository.create.mockRejectedValue(fkError);
+
+      await expect(
+        service.create('user-1', { ...dto, category_id: '00000000-0000-0000-0000-000000000099' }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -148,6 +175,18 @@ describe('ItemsService', () => {
       await expect(service.update('item-999', 'user-1', { name: 'x' })).rejects.toThrow(
         NotFoundException,
       );
+    });
+
+    it('throws BadRequestException when category_id does not exist (P2003)', async () => {
+      const fkError = new Prisma.PrismaClientKnownRequestError('FK violation', {
+        code: 'P2003',
+        clientVersion: '0.0.0',
+      });
+      itemsRepository.update.mockRejectedValue(fkError);
+
+      await expect(
+        service.update('item-1', 'user-1', { category_id: '00000000-0000-0000-0000-000000000099' }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -46,6 +46,8 @@ describe('ItemsService', () => {
       name: 'My Item',
       description: null,
       quantity: 1,
+      category_id: null,
+      category: null,
       user_defined_value: null,
       created_at: new Date('2026-01-01'),
     };
@@ -70,6 +72,7 @@ describe('ItemsService', () => {
         description: null,
         quantity: 1,
         user_defined_value: null,
+        category: null,
         images: [],
         created_at: new Date('2026-01-01'),
       });
@@ -80,6 +83,22 @@ describe('ItemsService', () => {
 
       await expect(service.create('user-1', dto)).rejects.toThrow(NotFoundException);
       expect(itemsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('includes category object in response when category_id is provided', async () => {
+      const category = { id: 'cat-1', name: 'Eletrônicos' };
+      listsRepository.findOneByUser.mockResolvedValue({
+        id: 'list-1',
+        user_id: 'user-1',
+        name: 'My List',
+        location: null,
+        created_at: new Date(),
+      });
+      itemsRepository.create.mockResolvedValue({ ...mockItem, category_id: 'cat-1', category });
+
+      const result = await service.create('user-1', { ...dto, category_id: 'cat-1' });
+
+      expect(result.category).toEqual(category);
     });
 
     it('converts user_defined_value Decimal to number in response', async () => {
@@ -108,6 +127,8 @@ describe('ItemsService', () => {
       name: 'Updated',
       description: null,
       quantity: 1,
+      category_id: null,
+      category: null,
       user_defined_value: null,
       created_at: new Date(),
     };
@@ -118,7 +139,7 @@ describe('ItemsService', () => {
       const result = await service.update('item-1', 'user-1', { name: 'Updated' });
 
       expect(itemsRepository.update).toHaveBeenCalledWith('item-1', 'user-1', { name: 'Updated' });
-      expect(result).toMatchObject({ id: 'item-1', name: 'Updated', images: [] });
+      expect(result).toMatchObject({ id: 'item-1', name: 'Updated', category: null, images: [] });
     });
 
     it('throws NotFoundException when item not found or not owned', async () => {
@@ -156,6 +177,8 @@ describe('ItemsService', () => {
           name: 'vintage lamp',
           description: null,
           quantity: 1,
+          category_id: null,
+          category: null,
           user_defined_value: null,
           created_at: createdAt,
         },
@@ -172,6 +195,7 @@ describe('ItemsService', () => {
           description: null,
           quantity: 1,
           user_defined_value: null,
+          category: null,
           images: [],
           created_at: createdAt,
         },
@@ -187,6 +211,8 @@ describe('ItemsService', () => {
           name: 'lamp',
           description: null,
           quantity: 1,
+          category_id: null,
+          category: null,
           user_defined_value: { valueOf: () => 5.5 } as any,
           created_at: createdAt,
         },
@@ -207,7 +233,13 @@ describe('ItemsService', () => {
   });
 
   describe('getByList', () => {
-    const mockList = { id: 'list-1', user_id: 'user-1', name: 'My List', location: null, created_at: new Date() };
+    const mockList = {
+      id: 'list-1',
+      user_id: 'user-1',
+      name: 'My List',
+      location: null,
+      created_at: new Date(),
+    };
     const makeItem = (id: string, createdAt = new Date()) => ({
       id,
       list_id: 'list-1',
@@ -215,6 +247,8 @@ describe('ItemsService', () => {
       description: null,
       quantity: 1,
       location: null,
+      category_id: null,
+      category: null,
       user_defined_value: null,
       created_at: createdAt,
     });

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { ItemsRepository } from './items.repository';
 import { ListsRepository } from '../lists/lists.repository';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
+import { Prisma } from '../../generated/prisma/client';
 
 @Injectable()
 export class ItemsService {
@@ -16,7 +17,15 @@ export class ItemsService {
     if (!list) {
       throw new NotFoundException('List not found');
     }
-    const item = await this.repository.create(dto);
+    let item: Awaited<ReturnType<typeof this.repository.create>>;
+    try {
+      item = await this.repository.create(dto);
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
+        throw new BadRequestException('Invalid category_id: category not found');
+      }
+      throw err;
+    }
     return {
       id: item.id,
       name: item.name,
@@ -30,7 +39,15 @@ export class ItemsService {
   }
 
   async update(id: string, userId: string, dto: UpdateItemDto) {
-    const item = await this.repository.update(id, userId, dto);
+    let item: Awaited<ReturnType<typeof this.repository.update>>;
+    try {
+      item = await this.repository.update(id, userId, dto);
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
+        throw new BadRequestException('Invalid category_id: category not found');
+      }
+      throw err;
+    }
     if (!item) {
       throw new NotFoundException('Item not found');
     }

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -23,6 +23,7 @@ export class ItemsService {
       description: item.description,
       quantity: item.quantity,
       user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
+      category: item.category ?? null,
       images: [],
       created_at: item.created_at,
     };
@@ -39,6 +40,7 @@ export class ItemsService {
       description: item.description,
       quantity: item.quantity,
       user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
+      category: item.category ?? null,
       images: [],
       created_at: item.created_at,
     };
@@ -59,6 +61,7 @@ export class ItemsService {
       description: item.description,
       quantity: item.quantity,
       user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
+      category: item.category ?? null,
       images: [],
       created_at: item.created_at,
     }));
@@ -83,6 +86,7 @@ export class ItemsService {
         quantity: item.quantity,
         user_defined_value:
           item.user_defined_value != null ? Number(item.user_defined_value) : null,
+        category: item.category ?? null,
         images: [],
         created_at: item.created_at,
       })),

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -12,20 +12,19 @@ export class ItemsService {
     private readonly listsRepository: ListsRepository,
   ) {}
 
+  private rethrowFkError(err: unknown): never {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
+      throw new BadRequestException('Invalid category_id: category not found');
+    }
+    throw err;
+  }
+
   async create(userId: string, dto: CreateItemDto) {
     const list = await this.listsRepository.findOneByUser(dto.list_id, userId);
     if (!list) {
       throw new NotFoundException('List not found');
     }
-    let item: Awaited<ReturnType<typeof this.repository.create>>;
-    try {
-      item = await this.repository.create(dto);
-    } catch (err) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-        throw new BadRequestException('Invalid category_id: category not found');
-      }
-      throw err;
-    }
+    const item = await this.repository.create(dto).catch((err) => this.rethrowFkError(err));
     return {
       id: item.id,
       name: item.name,
@@ -39,15 +38,9 @@ export class ItemsService {
   }
 
   async update(id: string, userId: string, dto: UpdateItemDto) {
-    let item: Awaited<ReturnType<typeof this.repository.update>>;
-    try {
-      item = await this.repository.update(id, userId, dto);
-    } catch (err) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
-        throw new BadRequestException('Invalid category_id: category not found');
-      }
-      throw err;
-    }
+    const item = await this.repository
+      .update(id, userId, dto)
+      .catch((err) => this.rethrowFkError(err));
     if (!item) {
       throw new NotFoundException('Item not found');
     }


### PR DESCRIPTION
Closes #22

## What changed

- Added `Category` model (`id`, `name unique`) to Prisma schema with two migrations; seeded with 10 Portuguese placeholder categories via `prisma/seed.ts` (idempotent upsert on name)
- Added nullable `category_id` FK to `Item` (SetNull on delete); repository now includes `category` relation in all `create`, `update`, `findOne`, `search`, and `findByList` queries
- `category_id` accepted as optional input on `POST /items` and `PATCH /items/:id`; all GET item responses include a `category` object (`{id, name}` or `null`)
- Fixed stale `LocationsModule` import in `app.module.ts` that was breaking the build

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (86/86)
- [ ] Run `npm run prisma:seed` and verify 10 categories are inserted idempotently
- [ ] `POST /items` with a valid `category_id` returns the category object in the response
- [ ] `POST /items` without `category_id` returns `"category": null`
- [ ] `PATCH /items/:id` with a `category_id` sets the category