### PR TITLE
feat: add main image upload to item creation

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -381,17 +381,51 @@
             "method": "POST",
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
                 "key": "Authorization",
                 "value": "Bearer {{accessToken}}"
               }
             ],
             "body": {
-              "mode": "raw",
-              "raw": "{\n  \"list_id\": \"<list-id>\",\n  \"name\": \"Vintage Lamp\",\n  \"description\": \"Brass floor lamp from the 1960s\",\n  \"quantity\": 1,\n  \"user_defined_value\": 85.0,\n  \"category_id\": \"<category-id>\"\n}"
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "list_id",
+                  "value": "<list-id>",
+                  "type": "text"
+                },
+                {
+                  "key": "name",
+                  "value": "Vintage Lamp",
+                  "type": "text"
+                },
+                {
+                  "key": "description",
+                  "value": "Brass floor lamp from the 1960s",
+                  "type": "text"
+                },
+                {
+                  "key": "quantity",
+                  "value": "1",
+                  "type": "text"
+                },
+                {
+                  "key": "user_defined_value",
+                  "value": "85.0",
+                  "type": "text"
+                },
+                {
+                  "key": "category_id",
+                  "value": "<category-id>",
+                  "type": "text"
+                },
+                {
+                  "key": "image",
+                  "type": "file",
+                  "src": "/path/to/image.jpg",
+                  "description": "Optional main image (JPEG, PNG, WebP, GIF — max 10 MB)",
+                  "disabled": true
+                }
+              ]
             },
             "url": {
               "raw": "{{baseUrl}}/items",
@@ -410,17 +444,36 @@
             "method": "PATCH",
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
                 "key": "Authorization",
                 "value": "Bearer {{accessToken}}"
               }
             ],
             "body": {
-              "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated Lamp\",\n  \"quantity\": 2,\n  \"category_id\": \"<category-id>\"\n}"
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "name",
+                  "value": "Updated Lamp",
+                  "type": "text"
+                },
+                {
+                  "key": "quantity",
+                  "value": "2",
+                  "type": "text"
+                },
+                {
+                  "key": "category_id",
+                  "value": "<category-id>",
+                  "type": "text"
+                },
+                {
+                  "key": "image",
+                  "type": "file",
+                  "src": "/path/to/new-image.jpg",
+                  "description": "Optional replacement main image (JPEG, PNG, WebP, GIF — max 10 MB)",
+                  "disabled": true
+                }
+              ]
             },
             "url": {
               "raw": "{{baseUrl}}/items/:id",

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,41 +95,39 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | /items?search= | Global item search by name |
-| POST | /items | Create item with final data (no AI, no image) |
-| PATCH | /items/:id | Update item fields |
+| POST | /items | Create item; optional image upload via multipart/form-data |
+| PATCH | /items/:id | Update item fields; optional image replacement |
 | DELETE | /items/:id | Delete item |
 
 ```json
-// POST /items — request (application/json)
-{
-  "list_id": "uuid",
-  "name": "string",
-  "description": "string",   // optional
-  "quantity": 1,             // optional, min 1
-  "category_id": "uuid",     // optional
-  "user_defined_value": 0    // optional
-}
+// POST /items — request (multipart/form-data)
+// Text fields:
+//   list_id: uuid (required)
+//   name: string (required)
+//   description: string (optional)
+//   quantity: number (optional, min 1, default 1)
+//   category_id: uuid (optional)
+//   user_defined_value: number (optional)
+// File fields:
+//   image: file (optional — JPEG, PNG, WebP, GIF, max 10 MB)
 
 // POST /items — response 201
 {
   "id": "uuid",
   "name": "string",
-  "description": "string",
+  "description": "string | null",
   "quantity": 1,
-  "user_defined_value": 0,
+  "user_defined_value": "number | null",
   "category": { "id": "uuid", "name": "string" },  // or null
-  "images": [],
+  "images": [
+    { "url": "string", "is_main": true }
+  ],  // empty array if no image uploaded
   "created_at": "timestamp"
 }
 
-// PATCH /items/:id — request (all fields optional)
-{
-  "name": "string",
-  "description": "string",
-  "quantity": 1,
-  "category_id": "uuid",
-  "user_defined_value": 0
-}
+// PATCH /items/:id — request (multipart/form-data, all fields optional)
+// Text fields: name, description, quantity, category_id, user_defined_value
+// File fields: image (replaces existing main image if provided)
 
 // PATCH /items/:id — response 200
 {
@@ -139,7 +137,9 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "quantity": 1,
   "user_defined_value": "number | null",
   "category": { "id": "uuid", "name": "string" },  // or null
-  "images": [],
+  "images": [
+    { "url": "string", "is_main": true }
+  ],  // empty array if no image exists
   "created_at": "timestamp"
 }
 ```
@@ -148,7 +148,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 ---
 
-## AI <Badge type="danger" text="Not Implemented" />
+## AI <Badge type="tip" text="Implemented" />
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -51,5 +51,8 @@ Global reference data — seeded on `prisma:seed`, no CRUD endpoints exposed.
 | Field | Type | Notes |
 |-------|------|-------|
 | id | uuid | PK |
-| item_id | uuid | FK → items |
+| item_id | uuid | FK → items, cascades on delete |
 | url | string | S3/R2 public URL |
+| storage_key | string | Object storage key (e.g. `items/{itemId}/{uuid}.jpg`); retained for future deletion |
+| is_main | boolean | True for the item's primary display image; default false |
+| created_at | timestamp | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ hero:
 | Auth (email + social) | <Badge type="warning" text="In Progress" /> |
 | Lists CRUD | <Badge type="tip" text="Implemented" /> |
 | Items CRUD | <Badge type="tip" text="Implemented" /> |
-| Image upload + storage | <Badge type="warning" text="In Progress" /> |
+| Image upload + storage | <Badge type="tip" text="Implemented" /> |
 | AI image analysis | <Badge type="tip" text="Implemented" /> |
 | Dashboard + search | <Badge type="danger" text="Not Implemented" /> |
 | Monetization tiers | <Badge type="danger" text="Not Implemented" /> |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,11 +18,11 @@
 - [x] Paginated items by list (`GET /lists/:id/items` — cursor-based)
 - [x] Category reference table with seeded Portuguese values; `category_id` on items
 
-## Milestone 3 — Image Upload + Storage <Badge type="warning" text="In Progress" />
+## Milestone 3 — Image Upload + Storage <Badge type="tip" text="Implemented" />
 
 - [x] S3-compatible storage abstraction
-- [ ] Image upload to S3/R2 on `POST /items`
-- [ ] `ItemImage` DB record created with returned URL
+- [x] Image upload to S3/R2 on `POST /items`
+- [x] `ItemImage` DB record created with returned URL
 
 ## Milestone 4 — AI Integration <Badge type="tip" text="Implemented" />
 

--- a/prisma/migrations/20260415012204_add_item_images/migration.sql
+++ b/prisma/migrations/20260415012204_add_item_images/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "item_images" (
+    "id" TEXT NOT NULL,
+    "item_id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "storage_key" TEXT NOT NULL,
+    "is_main" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "item_images_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "item_images_item_id_idx" ON "item_images"("item_id");
+
+-- AddForeignKey
+ALTER TABLE "item_images" ADD CONSTRAINT "item_images_item_id_fkey" FOREIGN KEY ("item_id") REFERENCES "items"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260415012204_add_item_images/migration.sql
+++ b/prisma/migrations/20260415012204_add_item_images/migration.sql
@@ -13,5 +13,7 @@ CREATE TABLE "item_images" (
 -- CreateIndex
 CREATE INDEX "item_images_item_id_idx" ON "item_images"("item_id");
 
+-- CreateIndex
+CREATE UNIQUE INDEX "item_images_one_main_per_item_idx" ON "item_images"("item_id") WHERE "is_main" = true;
 -- AddForeignKey
 ALTER TABLE "item_images" ADD CONSTRAINT "item_images_item_id_fkey" FOREIGN KEY ("item_id") REFERENCES "items"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,9 +62,23 @@ model Item {
   user_defined_value Decimal?
   created_at         DateTime @default(now()) @map("created_at")
 
-  list     List      @relation(fields: [list_id], references: [id], onDelete: Cascade)
-  category Category? @relation(fields: [category_id], references: [id], onDelete: SetNull)
+  list     List        @relation(fields: [list_id], references: [id], onDelete: Cascade)
+  category Category?   @relation(fields: [category_id], references: [id], onDelete: SetNull)
+  images   ItemImage[]
 
   @@index([list_id])
   @@map("items")
+}
+
+model ItemImage {
+  id          String   @id @default(uuid())
+  item_id     String
+  item        Item     @relation(fields: [item_id], references: [id], onDelete: Cascade)
+  url         String
+  storage_key String
+  is_main     Boolean  @default(false)
+  created_at  DateTime @default(now()) @map("created_at")
+
+  @@index([item_id])
+  @@map("item_images")
 }

--- a/src/common/utils/image-validation.ts
+++ b/src/common/utils/image-validation.ts
@@ -1,0 +1,65 @@
+import { BadRequestException } from '@nestjs/common';
+
+export const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
+export const ALLOWED_IMAGE_MIMETYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+export function multerImageFileFilter(
+  _req: unknown,
+  file: Express.Multer.File,
+  cb: (error: Error | null, acceptFile: boolean) => void,
+) {
+  if (ALLOWED_IMAGE_MIMETYPES.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new BadRequestException('Only image files are allowed'), false);
+  }
+}
+
+export function detectMimeFromMagicBytes(buf: Buffer): string | null {
+  if (buf.length < 12) return null;
+  // JPEG: SOI (FF D8) + next marker byte (FF)
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
+  // PNG: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47 &&
+    buf[4] === 0x0d &&
+    buf[5] === 0x0a &&
+    buf[6] === 0x1a &&
+    buf[7] === 0x0a
+  )
+    return 'image/png';
+  // GIF: GIF87a (37 61) or GIF89a (39 61)
+  if (
+    buf[0] === 0x47 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x38 &&
+    (buf[4] === 0x37 || buf[4] === 0x39) &&
+    buf[5] === 0x61
+  )
+    return 'image/gif';
+  // WebP: RIFF (4 bytes) + file size (4 bytes) + WEBP (4 bytes)
+  if (
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  )
+    return 'image/webp';
+  return null;
+}
+
+export function validateImageMagicBytes(buf: Buffer): string {
+  const actualMime = detectMimeFromMagicBytes(buf);
+  if (!actualMime || !ALLOWED_IMAGE_MIMETYPES.includes(actualMime)) {
+    throw new BadRequestException('Only image files are allowed');
+  }
+  return actualMime;
+}

--- a/src/modules/ai/ai.controller.ts
+++ b/src/modules/ai/ai.controller.ts
@@ -10,50 +10,11 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
 import { AiService } from './ai.service';
-
-const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
-const ALLOWED_MIMETYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-
-function detectMimeFromMagicBytes(buf: Buffer): string | null {
-  if (buf.length < 12) return null;
-  // JPEG: SOI (FF D8) + next marker byte (FF)
-  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
-  // PNG: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A
-  if (
-    buf[0] === 0x89 &&
-    buf[1] === 0x50 &&
-    buf[2] === 0x4e &&
-    buf[3] === 0x47 &&
-    buf[4] === 0x0d &&
-    buf[5] === 0x0a &&
-    buf[6] === 0x1a &&
-    buf[7] === 0x0a
-  )
-    return 'image/png';
-  // GIF: GIF87a (37 61) or GIF89a (39 61)
-  if (
-    buf[0] === 0x47 &&
-    buf[1] === 0x49 &&
-    buf[2] === 0x46 &&
-    buf[3] === 0x38 &&
-    (buf[4] === 0x37 || buf[4] === 0x39) &&
-    buf[5] === 0x61
-  )
-    return 'image/gif';
-  // WebP: RIFF (4 bytes) + file size (4 bytes) + WEBP (4 bytes)
-  if (
-    buf[0] === 0x52 &&
-    buf[1] === 0x49 &&
-    buf[2] === 0x46 &&
-    buf[3] === 0x46 &&
-    buf[8] === 0x57 &&
-    buf[9] === 0x45 &&
-    buf[10] === 0x42 &&
-    buf[11] === 0x50
-  )
-    return 'image/webp';
-  return null;
-}
+import {
+  MAX_IMAGE_SIZE,
+  multerImageFileFilter,
+  validateImageMagicBytes,
+} from '../../common/utils/image-validation';
 
 @Controller('ai')
 export class AiController {
@@ -64,24 +25,15 @@ export class AiController {
   @UseInterceptors(
     FileInterceptor('image', {
       storage: memoryStorage(),
-      limits: { fileSize: MAX_SIZE },
-      fileFilter: (_req, file, cb) => {
-        if (ALLOWED_MIMETYPES.includes(file.mimetype)) {
-          cb(null, true);
-        } else {
-          cb(new BadRequestException('Only image files are allowed'), false);
-        }
-      },
+      limits: { fileSize: MAX_IMAGE_SIZE },
+      fileFilter: multerImageFileFilter,
     }),
   )
   analyze(@UploadedFile() file: Express.Multer.File) {
     if (!file) {
       throw new BadRequestException('Image file is required');
     }
-    const actualMime = detectMimeFromMagicBytes(file.buffer);
-    if (!actualMime || !ALLOWED_MIMETYPES.includes(actualMime)) {
-      throw new BadRequestException('Only image files are allowed');
-    }
+    const actualMime = validateImageMagicBytes(file.buffer);
     return this.aiService.analyze(file.buffer, actualMime);
   }
 }

--- a/src/modules/items/dto/create-item.dto.ts
+++ b/src/modules/items/dto/create-item.dto.ts
@@ -28,7 +28,4 @@ export class CreateItemDto {
   @IsUUID()
   @IsOptional()
   category_id?: string;
-
-  @IsOptional()
-  image?: unknown;
 }

--- a/src/modules/items/items.controller.spec.ts
+++ b/src/modules/items/items.controller.spec.ts
@@ -57,9 +57,9 @@ describe('ItemsController', () => {
       const expected = { id: 'item-1', name: 'My Item', images: [], created_at: new Date() };
       mockItemsService.create.mockResolvedValue(expected);
 
-      const result = await controller.create(dto as any, makeReq('user-1'));
+      const result = await controller.create(dto as any, makeReq('user-1'), undefined);
 
-      expect(mockItemsService.create).toHaveBeenCalledWith('user-1', dto);
+      expect(mockItemsService.create).toHaveBeenCalledWith('user-1', dto, undefined);
       expect(result).toBe(expected);
     });
 
@@ -74,9 +74,9 @@ describe('ItemsController', () => {
       const dto = { name: 'Updated' };
       mockItemsService.update.mockResolvedValue(undefined);
 
-      await controller.update('item-1', dto as any, makeReq('user-1'));
+      await controller.update('item-1', dto as any, makeReq('user-1'), undefined);
 
-      expect(mockItemsService.update).toHaveBeenCalledWith('item-1', 'user-1', dto);
+      expect(mockItemsService.update).toHaveBeenCalledWith('item-1', 'user-1', dto, undefined);
     });
 
     it('is NOT marked @Public so JwtAuthGuard protects it', () => {

--- a/src/modules/items/items.controller.ts
+++ b/src/modules/items/items.controller.ts
@@ -10,11 +10,22 @@ import {
   Post,
   Query,
   Req,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 import { Request } from 'express';
 import { ItemsService } from './items.service';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
+import { MAX_IMAGE_SIZE, multerImageFileFilter } from '../../common/utils/image-validation';
+
+const imageInterceptor = FileInterceptor('image', {
+  storage: memoryStorage(),
+  limits: { fileSize: MAX_IMAGE_SIZE },
+  fileFilter: multerImageFileFilter,
+});
 
 @Controller('items')
 export class ItemsController {
@@ -28,15 +39,26 @@ export class ItemsController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  create(@Body() dto: CreateItemDto, @Req() req: Request) {
+  @UseInterceptors(imageInterceptor)
+  create(
+    @Body() dto: CreateItemDto,
+    @Req() req: Request,
+    @UploadedFile() image?: Express.Multer.File,
+  ) {
     const user = req.user as { id: string };
-    return this.itemsService.create(user.id, dto);
+    return this.itemsService.create(user.id, dto, image);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateItemDto, @Req() req: Request) {
+  @UseInterceptors(imageInterceptor)
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateItemDto,
+    @Req() req: Request,
+    @UploadedFile() image?: Express.Multer.File,
+  ) {
     const user = req.user as { id: string };
-    return this.itemsService.update(id, user.id, dto);
+    return this.itemsService.update(id, user.id, dto, image);
   }
 
   @Delete(':id')

--- a/src/modules/items/items.module.ts
+++ b/src/modules/items/items.module.ts
@@ -3,9 +3,10 @@ import { ItemsController } from './items.controller';
 import { ItemsService } from './items.service';
 import { ItemsRepository } from './items.repository';
 import { ListsModule } from '../lists/lists.module';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
-  imports: [forwardRef(() => ListsModule)],
+  imports: [forwardRef(() => ListsModule), StorageModule],
   controllers: [ItemsController],
   providers: [ItemsService, ItemsRepository],
   exports: [ItemsService],

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -3,6 +3,10 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
 
+type ImagePayload = { url: string; storageKey: string; isMain: boolean };
+
+const includeImages = { category: true, images: true } as const;
+
 @Injectable()
 export class ItemsRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -17,18 +21,43 @@ export class ItemsRepository {
         category_id: dto.category_id,
         user_defined_value: dto.user_defined_value,
       },
-      include: { category: true },
+      include: includeImages,
+    });
+  }
+
+  createWithImage(dto: CreateItemDto, itemId: string, image: ImagePayload) {
+    return this.prisma.$transaction(async (tx) => {
+      const item = await tx.item.create({
+        data: {
+          id: itemId,
+          list_id: dto.list_id,
+          name: dto.name,
+          description: dto.description,
+          quantity: dto.quantity ?? 1,
+          category_id: dto.category_id,
+          user_defined_value: dto.user_defined_value,
+        },
+      });
+      await tx.itemImage.create({
+        data: {
+          item_id: item.id,
+          url: image.url,
+          storage_key: image.storageKey,
+          is_main: image.isMain,
+        },
+      });
+      return tx.item.findUniqueOrThrow({ where: { id: item.id }, include: includeImages });
     });
   }
 
   findOneOwnedByUser(id: string, userId: string) {
     return this.prisma.item.findFirst({
       where: { id, list: { user_id: userId } },
-      include: { category: true },
+      include: includeImages,
     });
   }
 
-  async update(id: string, userId: string, dto: UpdateItemDto) {
+  async update(id: string, userId: string, dto: UpdateItemDto, image?: ImagePayload) {
     const result = await this.prisma.item.updateMany({
       where: { id, list: { user_id: userId } },
       data: {
@@ -42,7 +71,22 @@ export class ItemsRepository {
       },
     });
     if (result.count === 0) return null;
-    return this.prisma.item.findFirst({ where: { id }, include: { category: true } });
+
+    if (image) {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.itemImage.deleteMany({ where: { item_id: id, is_main: true } });
+        await tx.itemImage.create({
+          data: {
+            item_id: id,
+            url: image.url,
+            storage_key: image.storageKey,
+            is_main: image.isMain,
+          },
+        });
+      });
+    }
+
+    return this.prisma.item.findFirst({ where: { id }, include: includeImages });
   }
 
   async delete(id: string, userId: string) {
@@ -59,7 +103,7 @@ export class ItemsRepository {
         name: { contains: search, mode: 'insensitive' },
       },
       orderBy: { created_at: 'desc' },
-      include: { category: true },
+      include: includeImages,
     });
   }
 
@@ -69,7 +113,7 @@ export class ItemsRepository {
       orderBy: [{ created_at: 'desc' }, { id: 'desc' }],
       take: limit + 1,
       ...(cursor && { cursor: { id: cursor }, skip: 1 }),
-      include: { category: true },
+      include: includeImages,
     });
   }
 }

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -58,22 +58,22 @@ export class ItemsRepository {
   }
 
   async update(id: string, userId: string, dto: UpdateItemDto, image?: ImagePayload) {
-    const result = await this.prisma.item.updateMany({
-      where: { id, list: { user_id: userId } },
-      data: {
-        ...(dto.name != null && { name: dto.name }),
-        ...(dto.description != null && { description: dto.description }),
-        ...(dto.quantity != null && { quantity: dto.quantity }),
-        ...(dto.category_id !== undefined && { category_id: dto.category_id }),
-        ...(dto.user_defined_value != null && {
-          user_defined_value: dto.user_defined_value,
-        }),
-      },
-    });
-    if (result.count === 0) return null;
+    return this.prisma.$transaction(async (tx) => {
+      const result = await tx.item.updateMany({
+        where: { id, list: { user_id: userId } },
+        data: {
+          ...(dto.name != null && { name: dto.name }),
+          ...(dto.description != null && { description: dto.description }),
+          ...(dto.quantity != null && { quantity: dto.quantity }),
+          ...(dto.category_id !== undefined && { category_id: dto.category_id }),
+          ...(dto.user_defined_value != null && {
+            user_defined_value: dto.user_defined_value,
+          }),
+        },
+      });
+      if (result.count === 0) return null;
 
-    if (image) {
-      await this.prisma.$transaction(async (tx) => {
+      if (image) {
         await tx.itemImage.deleteMany({ where: { item_id: id, is_main: true } });
         await tx.itemImage.create({
           data: {
@@ -83,10 +83,10 @@ export class ItemsRepository {
             is_main: image.isMain,
           },
         });
-      });
-    }
+      }
 
-    return this.prisma.item.findFirst({ where: { id }, include: includeImages });
+      return tx.item.findFirst({ where: { id }, include: includeImages });
+    });
   }
 
   async delete(id: string, userId: string) {

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -218,6 +218,7 @@ describe('ItemsService', () => {
     const mockUpdatedItem = makeItem({ name: 'Updated' });
 
     it('returns the updated item when found', async () => {
+      itemsRepository.findOneOwnedByUser.mockResolvedValue(makeItem() as any);
       itemsRepository.update.mockResolvedValue(mockUpdatedItem as any);
 
       const result = await service.update('item-1', 'user-1', { name: 'Updated' });
@@ -232,6 +233,7 @@ describe('ItemsService', () => {
     });
 
     it('uploads new image and replaces main image record', async () => {
+      itemsRepository.findOneOwnedByUser.mockResolvedValue(makeItem() as any);
       storageService.upload.mockResolvedValue('https://cdn.example.com/items/item-1/new.jpg');
       const itemWithNewImage = makeItem({
         name: 'Updated',
@@ -261,14 +263,17 @@ describe('ItemsService', () => {
     });
 
     it('throws NotFoundException when item not found or not owned', async () => {
-      itemsRepository.update.mockResolvedValue(null);
+      itemsRepository.findOneOwnedByUser.mockResolvedValue(null);
 
       await expect(service.update('item-999', 'user-1', { name: 'x' })).rejects.toThrow(
         NotFoundException,
       );
+      expect(storageService.upload).not.toHaveBeenCalled();
+      expect(itemsRepository.update).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException when category_id does not exist (P2003)', async () => {
+      itemsRepository.findOneOwnedByUser.mockResolvedValue(makeItem() as any);
       const fkError = new Prisma.PrismaClientKnownRequestError('FK violation', {
         code: 'P2003',
         clientVersion: '0.0.0',
@@ -300,7 +305,7 @@ describe('ItemsService', () => {
   describe('search', () => {
     it('delegates to repository with userId and query and returns mapped response', async () => {
       const createdAt = new Date();
-      itemsRepository.searchByUser.mockResolvedValue([makeItem({ created_at: createdAt })] as any);
+      itemsRepository.searchByUser.mockResolvedValue([makeItem({ name: 'vintage lamp', created_at: createdAt })] as any);
 
       const result = await service.search('user-1', 'lamp');
 
@@ -308,7 +313,7 @@ describe('ItemsService', () => {
       expect(result).toEqual([
         {
           id: 'item-1',
-          name: 'My Item',
+          name: 'vintage lamp',
           description: null,
           quantity: 1,
           user_defined_value: null,

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -1,16 +1,75 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { ItemsService } from './items.service';
 import { ItemsRepository } from './items.repository';
 import { ListsRepository } from '../lists/lists.repository';
+import { STORAGE_SERVICE } from '../storage/storage.interface';
 import { Prisma } from '../../generated/prisma/client';
+
+const makeItem = (overrides: Partial<ReturnType<typeof baseItem>> = {}) => ({
+  ...baseItem(),
+  ...overrides,
+});
+
+function baseItem() {
+  return {
+    id: 'item-1',
+    list_id: 'list-1',
+    name: 'My Item',
+    description: null as string | null,
+    quantity: 1,
+    category_id: null as string | null,
+    category: null as { id: string; name: string } | null,
+    user_defined_value: null as { valueOf: () => number } | null,
+    images: [] as {
+      id: string;
+      item_id: string;
+      url: string;
+      storage_key: string;
+      is_main: boolean;
+      created_at: Date;
+    }[],
+    created_at: new Date('2026-01-01'),
+  };
+}
+
+const mockList = {
+  id: 'list-1',
+  user_id: 'user-1',
+  name: 'My List',
+  location: null,
+  created_at: new Date(),
+};
+
+const fakeImageFile = (
+  buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0]),
+): Express.Multer.File =>
+  ({
+    buffer: buf,
+    mimetype: 'image/jpeg',
+    originalname: 'photo.jpg',
+    size: buf.length,
+    fieldname: 'image',
+    encoding: '7bit',
+    stream: null as any,
+    destination: '',
+    filename: '',
+    path: '',
+  }) as Express.Multer.File;
 
 describe('ItemsService', () => {
   let service: ItemsService;
   let itemsRepository: jest.Mocked<ItemsRepository>;
   let listsRepository: jest.Mocked<ListsRepository>;
+  let storageService: { upload: jest.Mock };
 
   beforeEach(async () => {
+    storageService = { upload: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ItemsService,
@@ -18,6 +77,7 @@ describe('ItemsService', () => {
           provide: ItemsRepository,
           useValue: {
             create: jest.fn(),
+            createWithImage: jest.fn(),
             findOneOwnedByUser: jest.fn(),
             update: jest.fn(),
             delete: jest.fn(),
@@ -31,6 +91,10 @@ describe('ItemsService', () => {
             findOneByUser: jest.fn(),
           },
         },
+        {
+          provide: STORAGE_SERVICE,
+          useValue: storageService,
+        },
       ],
     }).compile();
 
@@ -41,32 +105,15 @@ describe('ItemsService', () => {
 
   describe('create', () => {
     const dto = { list_id: 'list-1', name: 'My Item' };
-    const mockItem = {
-      id: 'item-1',
-      list_id: 'list-1',
-      name: 'My Item',
-      description: null,
-      quantity: 1,
-      category_id: null,
-      category: null,
-      user_defined_value: null,
-      created_at: new Date('2026-01-01'),
-    };
 
-    it('creates item when list belongs to caller', async () => {
-      listsRepository.findOneByUser.mockResolvedValue({
-        id: 'list-1',
-        user_id: 'user-1',
-        name: 'My List',
-        location: null,
-        created_at: new Date(),
-      });
-      itemsRepository.create.mockResolvedValue(mockItem);
+    it('creates item without image when no file provided', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      itemsRepository.create.mockResolvedValue(makeItem() as any);
 
       const result = await service.create('user-1', dto);
 
-      expect(listsRepository.findOneByUser).toHaveBeenCalledWith('list-1', 'user-1');
       expect(itemsRepository.create).toHaveBeenCalledWith(dto);
+      expect(storageService.upload).not.toHaveBeenCalled();
       expect(result).toEqual({
         id: 'item-1',
         name: 'My Item',
@@ -79,6 +126,52 @@ describe('ItemsService', () => {
       });
     });
 
+    it('uploads image and creates item + image record when file provided', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      storageService.upload.mockResolvedValue('https://cdn.example.com/items/item-1/abc.jpg');
+      const itemWithImage = makeItem({
+        images: [
+          {
+            id: 'img-1',
+            item_id: 'item-1',
+            url: 'https://cdn.example.com/items/item-1/abc.jpg',
+            storage_key: 'items/item-1/abc.jpg',
+            is_main: true,
+            created_at: new Date(),
+          },
+        ],
+      });
+      itemsRepository.createWithImage.mockResolvedValue(itemWithImage as any);
+
+      const result = await service.create('user-1', dto, fakeImageFile());
+
+      expect(storageService.upload).toHaveBeenCalledTimes(1);
+      expect(itemsRepository.createWithImage).toHaveBeenCalledTimes(1);
+      expect(itemsRepository.create).not.toHaveBeenCalled();
+      expect(result.images).toHaveLength(1);
+      expect(result.images[0].is_main).toBe(true);
+    });
+
+    it('does not persist item when storage upload throws', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      storageService.upload.mockRejectedValue(new Error('S3 down'));
+
+      await expect(service.create('user-1', dto, fakeImageFile())).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(itemsRepository.createWithImage).not.toHaveBeenCalled();
+      expect(itemsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException for invalid MIME type (magic bytes mismatch)', async () => {
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      // Buffer that doesn't match any known magic bytes
+      const badFile = fakeImageFile(Buffer.alloc(16, 0));
+
+      await expect(service.create('user-1', dto, badFile)).rejects.toThrow(BadRequestException);
+      expect(storageService.upload).not.toHaveBeenCalled();
+    });
+
     it('throws NotFoundException when list does not belong to caller', async () => {
       listsRepository.findOneByUser.mockResolvedValue(null);
 
@@ -88,39 +181,19 @@ describe('ItemsService', () => {
 
     it('includes category object in response when category_id is provided', async () => {
       const category = { id: '00000000-0000-0000-0000-000000000001', name: 'Eletrônicos' };
-      listsRepository.findOneByUser.mockResolvedValue({
-        id: 'list-1',
-        user_id: 'user-1',
-        name: 'My List',
-        location: null,
-        created_at: new Date(),
-      });
-      itemsRepository.create.mockResolvedValue({
-        ...mockItem,
-        category_id: '00000000-0000-0000-0000-000000000001',
-        category,
-      });
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      itemsRepository.create.mockResolvedValue(makeItem({ category_id: category.id, category }) as any);
 
-      const result = await service.create('user-1', {
-        ...dto,
-        category_id: '00000000-0000-0000-0000-000000000001',
-      });
+      const result = await service.create('user-1', { ...dto, category_id: category.id });
 
       expect(result.category).toEqual(category);
     });
 
     it('converts user_defined_value Decimal to number in response', async () => {
-      listsRepository.findOneByUser.mockResolvedValue({
-        id: 'list-1',
-        user_id: 'user-1',
-        name: 'My List',
-        location: null,
-        created_at: new Date(),
-      });
-      itemsRepository.create.mockResolvedValue({
-        ...mockItem,
-        user_defined_value: { valueOf: () => 9.99 } as any,
-      });
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
+      itemsRepository.create.mockResolvedValue(
+        makeItem({ user_defined_value: { valueOf: () => 9.99 } as any }) as any,
+      );
 
       const result = await service.create('user-1', { ...dto, user_defined_value: 9.99 });
 
@@ -128,13 +201,7 @@ describe('ItemsService', () => {
     });
 
     it('throws BadRequestException when category_id does not exist (P2003)', async () => {
-      listsRepository.findOneByUser.mockResolvedValue({
-        id: 'list-1',
-        user_id: 'user-1',
-        name: 'My List',
-        location: null,
-        created_at: new Date(),
-      });
+      listsRepository.findOneByUser.mockResolvedValue(mockList);
       const fkError = new Prisma.PrismaClientKnownRequestError('FK violation', {
         code: 'P2003',
         clientVersion: '0.0.0',
@@ -148,25 +215,49 @@ describe('ItemsService', () => {
   });
 
   describe('update', () => {
-    const mockUpdatedItem = {
-      id: 'item-1',
-      list_id: 'list-1',
-      name: 'Updated',
-      description: null,
-      quantity: 1,
-      category_id: null,
-      category: null,
-      user_defined_value: null,
-      created_at: new Date(),
-    };
+    const mockUpdatedItem = makeItem({ name: 'Updated' });
 
     it('returns the updated item when found', async () => {
-      itemsRepository.update.mockResolvedValue(mockUpdatedItem);
+      itemsRepository.update.mockResolvedValue(mockUpdatedItem as any);
 
       const result = await service.update('item-1', 'user-1', { name: 'Updated' });
 
-      expect(itemsRepository.update).toHaveBeenCalledWith('item-1', 'user-1', { name: 'Updated' });
+      expect(itemsRepository.update).toHaveBeenCalledWith(
+        'item-1',
+        'user-1',
+        { name: 'Updated' },
+        undefined,
+      );
       expect(result).toMatchObject({ id: 'item-1', name: 'Updated', category: null, images: [] });
+    });
+
+    it('uploads new image and replaces main image record', async () => {
+      storageService.upload.mockResolvedValue('https://cdn.example.com/items/item-1/new.jpg');
+      const itemWithNewImage = makeItem({
+        name: 'Updated',
+        images: [
+          {
+            id: 'img-2',
+            item_id: 'item-1',
+            url: 'https://cdn.example.com/items/item-1/new.jpg',
+            storage_key: 'items/item-1/new.jpg',
+            is_main: true,
+            created_at: new Date(),
+          },
+        ],
+      });
+      itemsRepository.update.mockResolvedValue(itemWithNewImage as any);
+
+      const result = await service.update('item-1', 'user-1', { name: 'Updated' }, fakeImageFile());
+
+      expect(storageService.upload).toHaveBeenCalledTimes(1);
+      expect(itemsRepository.update).toHaveBeenCalledWith(
+        'item-1',
+        'user-1',
+        { name: 'Updated' },
+        expect.objectContaining({ isMain: true }),
+      );
+      expect(result.images[0].is_main).toBe(true);
     });
 
     it('throws NotFoundException when item not found or not owned', async () => {
@@ -209,20 +300,7 @@ describe('ItemsService', () => {
   describe('search', () => {
     it('delegates to repository with userId and query and returns mapped response', async () => {
       const createdAt = new Date();
-      const items = [
-        {
-          id: 'item-1',
-          list_id: 'list-1',
-          name: 'vintage lamp',
-          description: null,
-          quantity: 1,
-          category_id: null,
-          category: null,
-          user_defined_value: null,
-          created_at: createdAt,
-        },
-      ];
-      itemsRepository.searchByUser.mockResolvedValue(items);
+      itemsRepository.searchByUser.mockResolvedValue([makeItem({ created_at: createdAt })] as any);
 
       const result = await service.search('user-1', 'lamp');
 
@@ -230,7 +308,7 @@ describe('ItemsService', () => {
       expect(result).toEqual([
         {
           id: 'item-1',
-          name: 'vintage lamp',
+          name: 'My Item',
           description: null,
           quantity: 1,
           user_defined_value: null,
@@ -242,20 +320,9 @@ describe('ItemsService', () => {
     });
 
     it('converts user_defined_value Decimal to number in search results', async () => {
-      const createdAt = new Date();
       itemsRepository.searchByUser.mockResolvedValue([
-        {
-          id: 'item-1',
-          list_id: 'list-1',
-          name: 'lamp',
-          description: null,
-          quantity: 1,
-          category_id: null,
-          category: null,
-          user_defined_value: { valueOf: () => 5.5 } as any,
-          created_at: createdAt,
-        },
-      ]);
+        makeItem({ user_defined_value: { valueOf: () => 5.5 } as any }),
+      ] as any);
 
       const result = await service.search('user-1', 'lamp');
 
@@ -272,25 +339,8 @@ describe('ItemsService', () => {
   });
 
   describe('getByList', () => {
-    const mockList = {
-      id: 'list-1',
-      user_id: 'user-1',
-      name: 'My List',
-      location: null,
-      created_at: new Date(),
-    };
-    const makeItem = (id: string, createdAt = new Date()) => ({
-      id,
-      list_id: 'list-1',
-      name: `Item ${id}`,
-      description: null,
-      quantity: 1,
-      location: null,
-      category_id: null,
-      category: null,
-      user_defined_value: null,
-      created_at: createdAt,
-    });
+    const makeListItem = (id: string, createdAt = new Date()) =>
+      makeItem({ id, list_id: 'list-1', name: `Item ${id}`, created_at: createdAt });
 
     it('throws NotFoundException when list does not belong to caller', async () => {
       listsRepository.findOneByUser.mockResolvedValue(null);
@@ -301,8 +351,8 @@ describe('ItemsService', () => {
 
     it('returns first page with nextCursor set when more items exist', async () => {
       listsRepository.findOneByUser.mockResolvedValue(mockList);
-      const rows = Array.from({ length: 21 }, (_, i) => makeItem(`item-${i}`));
-      itemsRepository.findByList.mockResolvedValue(rows);
+      const rows = Array.from({ length: 21 }, (_, i) => makeListItem(`item-${i}`));
+      itemsRepository.findByList.mockResolvedValue(rows as any);
 
       const result = await service.getByList('list-1', 'user-1', undefined, 20);
 
@@ -313,8 +363,10 @@ describe('ItemsService', () => {
 
     it('returns last page with nextCursor null when no more items', async () => {
       listsRepository.findOneByUser.mockResolvedValue(mockList);
-      const rows = [makeItem('item-1'), makeItem('item-2')];
-      itemsRepository.findByList.mockResolvedValue(rows);
+      itemsRepository.findByList.mockResolvedValue([
+        makeListItem('item-1'),
+        makeListItem('item-2'),
+      ] as any);
 
       const result = await service.getByList('list-1', 'user-1', 'cursor-id', 20);
 
@@ -334,7 +386,7 @@ describe('ItemsService', () => {
 
     it('passes cursor to repository when provided', async () => {
       listsRepository.findOneByUser.mockResolvedValue(mockList);
-      itemsRepository.findByList.mockResolvedValue([makeItem('item-5')]);
+      itemsRepository.findByList.mockResolvedValue([makeListItem('item-5')] as any);
 
       await service.getByList('list-1', 'user-1', 'cursor-abc', 10);
 
@@ -344,8 +396,8 @@ describe('ItemsService', () => {
     it('converts user_defined_value Decimal to number', async () => {
       listsRepository.findOneByUser.mockResolvedValue(mockList);
       itemsRepository.findByList.mockResolvedValue([
-        { ...makeItem('item-1'), user_defined_value: { valueOf: () => 12.5 } as any },
-      ]);
+        makeItem({ user_defined_value: { valueOf: () => 12.5 } as any }),
+      ] as any);
 
       const result = await service.getByList('list-1', 'user-1');
 

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -71,10 +71,23 @@ export class ItemsService {
         throw new InternalServerErrorException('Image upload failed');
       }
       imagePayload = { url, storageKey: key, isMain: true };
-      const item = await this.repository
-        .createWithImage(dto, itemId, imagePayload)
-        .catch((err) => this.rethrowFkError(err));
-      return this.mapItem(item);
+
+      try {
+        const item = await this.repository.createWithImage(dto, itemId, imagePayload);
+        return this.mapItem(item);
+      } catch (err) {
+        const storageWithDelete = this.storage as IStorageService & {
+          delete?: (key: string) => Promise<void>;
+        };
+
+        try {
+          await storageWithDelete.delete?.(key);
+        } catch {
+          // Best-effort cleanup; preserve the original repository error.
+        }
+
+        this.rethrowFkError(err);
+      }
     }
 
     const item = await this.repository.create(dto).catch((err) => this.rethrowFkError(err));

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -95,6 +95,11 @@ export class ItemsService {
   }
 
   async update(id: string, userId: string, dto: UpdateItemDto, imageFile?: Express.Multer.File) {
+    const existing = await this.repository.findOneOwnedByUser(id, userId);
+    if (!existing) {
+      throw new NotFoundException('Item not found');
+    }
+
     let imagePayload: { url: string; storageKey: string; isMain: true } | undefined;
 
     if (imageFile) {

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -1,15 +1,35 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { randomUUID } from 'crypto';
 import { ItemsRepository } from './items.repository';
 import { ListsRepository } from '../lists/lists.repository';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
 import { Prisma } from '../../generated/prisma/client';
+import { IStorageService, STORAGE_SERVICE } from '../storage/storage.interface';
+import { validateImageMagicBytes } from '../../common/utils/image-validation';
+
+function extFromMime(mime: string): string {
+  const map: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+    'image/gif': 'gif',
+  };
+  return map[mime] ?? 'bin';
+}
 
 @Injectable()
 export class ItemsService {
   constructor(
     private readonly repository: ItemsRepository,
     private readonly listsRepository: ListsRepository,
+    @Inject(STORAGE_SERVICE) private readonly storage: IStorageService,
   ) {}
 
   private rethrowFkError(err: unknown): never {
@@ -19,12 +39,7 @@ export class ItemsService {
     throw err;
   }
 
-  async create(userId: string, dto: CreateItemDto) {
-    const list = await this.listsRepository.findOneByUser(dto.list_id, userId);
-    if (!list) {
-      throw new NotFoundException('List not found');
-    }
-    const item = await this.repository.create(dto).catch((err) => this.rethrowFkError(err));
+  private mapItem(item: Awaited<ReturnType<ItemsRepository['create']>>) {
     return {
       id: item.id,
       name: item.name,
@@ -32,28 +47,62 @@ export class ItemsService {
       quantity: item.quantity,
       user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
       category: item.category ?? null,
-      images: [],
+      images: item.images.map((img) => ({ url: img.url, is_main: img.is_main })),
       created_at: item.created_at,
     };
   }
 
-  async update(id: string, userId: string, dto: UpdateItemDto) {
+  async create(userId: string, dto: CreateItemDto, imageFile?: Express.Multer.File) {
+    const list = await this.listsRepository.findOneByUser(dto.list_id, userId);
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+
+    let imagePayload: { url: string; storageKey: string; isMain: true } | undefined;
+
+    if (imageFile) {
+      const actualMime = validateImageMagicBytes(imageFile.buffer);
+      const itemId = randomUUID();
+      const key = `items/${itemId}/${randomUUID()}.${extFromMime(actualMime)}`;
+      let url: string;
+      try {
+        url = await this.storage.upload(imageFile.buffer, key, actualMime);
+      } catch {
+        throw new InternalServerErrorException('Image upload failed');
+      }
+      imagePayload = { url, storageKey: key, isMain: true };
+      const item = await this.repository
+        .createWithImage(dto, itemId, imagePayload)
+        .catch((err) => this.rethrowFkError(err));
+      return this.mapItem(item);
+    }
+
+    const item = await this.repository.create(dto).catch((err) => this.rethrowFkError(err));
+    return this.mapItem(item);
+  }
+
+  async update(id: string, userId: string, dto: UpdateItemDto, imageFile?: Express.Multer.File) {
+    let imagePayload: { url: string; storageKey: string; isMain: true } | undefined;
+
+    if (imageFile) {
+      const actualMime = validateImageMagicBytes(imageFile.buffer);
+      const key = `items/${id}/${randomUUID()}.${extFromMime(actualMime)}`;
+      let url: string;
+      try {
+        url = await this.storage.upload(imageFile.buffer, key, actualMime);
+      } catch {
+        throw new InternalServerErrorException('Image upload failed');
+      }
+      imagePayload = { url, storageKey: key, isMain: true };
+    }
+
     const item = await this.repository
-      .update(id, userId, dto)
+      .update(id, userId, dto, imagePayload)
       .catch((err) => this.rethrowFkError(err));
     if (!item) {
       throw new NotFoundException('Item not found');
     }
-    return {
-      id: item.id,
-      name: item.name,
-      description: item.description,
-      quantity: item.quantity,
-      user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
-      category: item.category ?? null,
-      images: [],
-      created_at: item.created_at,
-    };
+    return this.mapItem(item);
   }
 
   async remove(id: string, userId: string) {
@@ -65,16 +114,7 @@ export class ItemsService {
 
   async search(userId: string, query: string) {
     const items = await this.repository.searchByUser(userId, query);
-    return items.map((item) => ({
-      id: item.id,
-      name: item.name,
-      description: item.description,
-      quantity: item.quantity,
-      user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
-      category: item.category ?? null,
-      images: [],
-      created_at: item.created_at,
-    }));
+    return items.map((item) => this.mapItem(item));
   }
 
   async getByList(listId: string, userId: string, cursor?: string, limit: number = 20) {
@@ -89,17 +129,7 @@ export class ItemsService {
     const nextCursor = hasNextPage ? items[items.length - 1].id : null;
 
     return {
-      data: items.map((item) => ({
-        id: item.id,
-        name: item.name,
-        description: item.description,
-        quantity: item.quantity,
-        user_defined_value:
-          item.user_defined_value != null ? Number(item.user_defined_value) : null,
-        category: item.category ?? null,
-        images: [],
-        created_at: item.created_at,
-      })),
+      data: items.map((item) => this.mapItem(item)),
       nextCursor,
     };
   }


### PR DESCRIPTION
Closes #21

## What changed

- Added `ItemImage` Prisma model and migration (`item_images` table with `item_id`, `url`, `storage_key`, `is_main`)
- `POST /items` and `PATCH /items/:id` now accept an optional `image` file via `multipart/form-data`; upload goes to object storage and an `ItemImage` record is created atomically — if storage fails, no item is persisted
- All item responses now include an `images` array (`[{ url, is_main }]`); empty when no image exists
- Extracted image validation (magic-bytes check, MIME filter, size limit) to `src/common/utils/image-validation.ts`, shared by both `ai.controller.ts` and the new items flow

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (94 total)
- [ ] `POST /items` with form-data (no image) creates item with `images: []`
- [ ] `POST /items` with a JPEG file stores it in object storage and returns `images[0].is_main === true`
- [ ] `PATCH /items/:id` with a new image replaces the main image record
- [ ] Uploading an invalid file type or a file >10 MB is rejected before any storage call