### PR TITLE
feat: AI analyzer category matching and description extraction

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -30,7 +30,7 @@ The prompt is built dynamically with the current category list injected at call 
 ```
 Analyze the image and return a JSON object with the following fields:
 - name: item name in Portuguese (Brazil)
-- category: pick the single most fitting category from this list, or null if none fit: [Móveis, Eletrônicos, ...]
+- category: pick the single most fitting category from this list, or null if none fit: ["Móveis","Eletrônicos", ...]
 - description: brief item description in one paragraph, in Portuguese (Brazil)
 - price_min: minimum market value in BRL (number)
 - price_max: maximum market value in BRL (number)

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -8,10 +8,12 @@ OpenAI API — GPT-4o-mini (default) or GPT-4o
 
 ```
 POST /ai/analyze (image)
-  └─► OpenAI Vision API
-        └─► Returns { name, category, price_min, price_max }
-              └─► Backend normalizes prices
-                    └─► Returns suggestions to client
+  └─► DB: fetch all categories (id, name)
+        └─► OpenAI Vision API (prompt includes category list)
+              └─► Returns { name, category, description, price_min, price_max }
+                    └─► Backend resolves category_id (case-insensitive match)
+                          └─► Backend normalizes prices
+                                └─► Returns suggestions to client
 
 User reviews/edits suggestions
   └─► POST /items (final data + image)
@@ -23,16 +25,26 @@ AI is a **separate step** before item creation. The client sends the image to `/
 
 ## Prompt
 
+The prompt is built dynamically with the current category list injected at call time:
+
 ```
 Analyze the image and return a JSON object with the following fields:
 - name: item name in Portuguese (Brazil)
-- category: item category in Portuguese (Brazil)
+- category: pick the single most fitting category from this list, or null if none fit: [Móveis, Eletrônicos, ...]
+- description: brief item description in one paragraph, in Portuguese (Brazil)
 - price_min: minimum market value in BRL (number)
 - price_max: maximum market value in BRL (number)
 
 Return only valid JSON, no explanation:
-{ "name": "", "category": "", "price_min": 0, "price_max": 0 }
+{ "name": "", "category": "", "description": "", "price_min": 0, "price_max": 0 }
 ```
+
+## Category Matching
+
+After the AI returns a category name, the backend resolves `category_id`:
+- The returned name is matched case-insensitively against the fetched category list.
+- If a match is found, `category_id` is set to that category's UUID and `category` is normalized to the stored name.
+- If `null` is returned or the name is unrecognized, both `category` and `category_id` are `null`.
 
 ## Price Normalization
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -36,7 +36,7 @@ Analyze the image and return a JSON object with the following fields:
 - price_max: maximum market value in BRL (number)
 
 Return only valid JSON, no explanation:
-{ "name": "", "category": "", "description": "", "price_min": 0, "price_max": 0 }
+{ "name": "", "category": null, "description": "", "price_min": 0, "price_max": 0 }
 ```
 
 ## Category Matching

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,9 +161,14 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 // POST /ai/analyze — response 200
 {
   "name": "string",
-  "category": "string",
+  "category": "string | null",
+  "category_id": "uuid | null",
+  "description": "string",
   "price_min": 0,
   "price_max": 0
 }
+// category: name matched from seeded category list, or null if none fit
+// category_id: UUID of the matched category, or null
+// description: one-paragraph item description in Portuguese (Brazil)
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -167,8 +167,8 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "price_min": 0,
   "price_max": 0
 }
-// category: name matched from seeded category list, or null if none fit
-// category_id: UUID of the matched category, or null
+// category: seeded category name when matched; null when no seeded match exists
+// category_id: UUID of the matched seeded category, or null when no seeded match exists
 // description: one-paragraph item description in Portuguese (Brazil)
 ```
 

--- a/src/modules/ai/ai.service.spec.ts
+++ b/src/modules/ai/ai.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AiService } from './ai.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 const mockCreate = jest.fn();
 
@@ -16,11 +17,19 @@ jest.mock('openai', () => ({
   })),
 }));
 
+const mockCategories = [
+  { id: 'uuid-1', name: 'Eletrônicos' },
+  { id: 'uuid-2', name: 'Móveis' },
+];
+
 describe('AiService', () => {
   let service: AiService;
+  let prisma: { category: { findMany: jest.Mock } };
 
   beforeEach(async () => {
     mockCreate.mockReset();
+
+    prisma = { category: { findMany: jest.fn().mockResolvedValue(mockCategories) } };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -28,6 +37,10 @@ describe('AiService', () => {
         {
           provide: ConfigService,
           useValue: { getOrThrow: jest.fn().mockReturnValue('test-api-key') },
+        },
+        {
+          provide: PrismaService,
+          useValue: prisma,
         },
       ],
     }).compile();
@@ -43,23 +56,105 @@ describe('AiService', () => {
   }
 
   describe('analyze', () => {
-    it('returns parsed result for a valid OpenAI response', async () => {
-      const payload = { name: 'Cadeira', category: 'Móveis', price_min: 100, price_max: 500 };
+    it('returns parsed result for a valid OpenAI response with matching category', async () => {
+      const payload = {
+        name: 'Notebook',
+        category: 'Eletrônicos',
+        description: 'Um notebook moderno.',
+        price_min: 2000,
+        price_max: 5000,
+      };
       mockCreate.mockResolvedValue(makeOpenAIResponse(JSON.stringify(payload)));
 
       const result = await service.analyze(fakeBuffer, fakeMime);
 
-      expect(result).toEqual(payload);
+      expect(result.name).toBe('Notebook');
+      expect(result.category).toBe('Eletrônicos');
+      expect(result.category_id).toBe('uuid-1');
+      expect(result.description).toBe('Um notebook moderno.');
+      expect(result.price_min).toBe(2000);
+      expect(result.price_max).toBe(5000);
+    });
+
+    it('resolves category_id case-insensitively', async () => {
+      const payload = {
+        name: 'Cadeira',
+        category: 'móveis',
+        description: 'Uma cadeira confortável.',
+        price_min: 300,
+        price_max: 800,
+      };
+      mockCreate.mockResolvedValue(makeOpenAIResponse(JSON.stringify(payload)));
+
+      const result = await service.analyze(fakeBuffer, fakeMime);
+
+      expect(result.category).toBe('Móveis');
+      expect(result.category_id).toBe('uuid-2');
+    });
+
+    it('sets category_id to null when AI returns null for category', async () => {
+      const payload = {
+        name: 'Objeto Estranho',
+        category: null,
+        description: 'Um objeto de origem desconhecida.',
+        price_min: 10,
+        price_max: 50,
+      };
+      mockCreate.mockResolvedValue(makeOpenAIResponse(JSON.stringify(payload)));
+
+      const result = await service.analyze(fakeBuffer, fakeMime);
+
+      expect(result.category).toBeNull();
+      expect(result.category_id).toBeNull();
+    });
+
+    it('sets category_id to null when AI returns an unrecognized category name', async () => {
+      const payload = {
+        name: 'Item X',
+        category: 'CategoriaDesconhecida',
+        description: 'Descrição do item X.',
+        price_min: 100,
+        price_max: 200,
+      };
+      mockCreate.mockResolvedValue(makeOpenAIResponse(JSON.stringify(payload)));
+
+      const result = await service.analyze(fakeBuffer, fakeMime);
+
+      expect(result.category).toBe('CategoriaDesconhecida');
+      expect(result.category_id).toBeNull();
     });
 
     it('swaps price_min and price_max when price_min > price_max', async () => {
-      const payload = { name: 'Mesa', category: 'Móveis', price_min: 500, price_max: 100 };
+      const payload = {
+        name: 'Mesa',
+        category: 'Móveis',
+        description: 'Uma mesa de madeira.',
+        price_min: 500,
+        price_max: 100,
+      };
       mockCreate.mockResolvedValue(makeOpenAIResponse(JSON.stringify(payload)));
 
       const result = await service.analyze(fakeBuffer, fakeMime);
 
       expect(result.price_min).toBe(100);
       expect(result.price_max).toBe(500);
+    });
+
+    it('includes all category names in the built prompt', async () => {
+      const payload = {
+        name: 'TV',
+        category: 'Eletrônicos',
+        description: 'Uma televisão.',
+        price_min: 1000,
+        price_max: 3000,
+      };
+      mockCreate.mockResolvedValue(makeOpenAIResponse(JSON.stringify(payload)));
+
+      await service.analyze(fakeBuffer, fakeMime);
+
+      const promptText = mockCreate.mock.calls[0][0].messages[0].content[0].text as string;
+      expect(promptText).toContain('Eletrônicos');
+      expect(promptText).toContain('Móveis');
     });
 
     it('throws ServiceUnavailableException when OpenAI throws', async () => {

--- a/src/modules/ai/ai.service.spec.ts
+++ b/src/modules/ai/ai.service.spec.ts
@@ -108,7 +108,7 @@ describe('AiService', () => {
       expect(result.category_id).toBeNull();
     });
 
-    it('sets category_id to null when AI returns an unrecognized category name', async () => {
+    it('sets category and category_id to null when AI returns an unrecognized category name', async () => {
       const payload = {
         name: 'Item X',
         category: 'CategoriaDesconhecida',
@@ -120,7 +120,7 @@ describe('AiService', () => {
 
       const result = await service.analyze(fakeBuffer, fakeMime);
 
-      expect(result.category).toBe('CategoriaDesconhecida');
+      expect(result.category).toBeNull();
       expect(result.category_id).toBeNull();
     });
 

--- a/src/modules/ai/ai.service.ts
+++ b/src/modules/ai/ai.service.ts
@@ -1,19 +1,26 @@
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
 import OpenAI from 'openai';
 
-const ANALYZE_PROMPT = `Analyze the image and return a JSON object with the following fields:
+function buildPrompt(categoryNames: string[]): string {
+  const list = categoryNames.join(', ');
+  return `Analyze the image and return a JSON object with the following fields:
 - name: item name in Portuguese (Brazil)
-- category: item category in Portuguese (Brazil)
+- category: pick the single most fitting category from this list, or null if none fit: [${list}]
+- description: brief item description in one paragraph, in Portuguese (Brazil)
 - price_min: minimum market value in BRL (number)
 - price_max: maximum market value in BRL (number)
 
 Return only valid JSON, no explanation:
-{ "name": "", "category": "", "price_min": 0, "price_max": 0 }`;
+{ "name": "", "category": "", "description": "", "price_min": 0, "price_max": 0 }`;
+}
 
 export interface AnalyzeResult {
   name: string;
-  category: string;
+  category: string | null;
+  category_id: string | null;
+  description: string;
   price_min: number;
   price_max: number;
 }
@@ -23,7 +30,10 @@ export class AiService {
   private readonly logger = new Logger(AiService.name);
   private readonly openai: OpenAI;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {
     this.openai = new OpenAI({
       apiKey: this.config.getOrThrow<string>('OPENAI_API_KEY'),
     });
@@ -31,6 +41,9 @@ export class AiService {
 
   async analyze(imageBuffer: Buffer, mimetype: string): Promise<AnalyzeResult> {
     try {
+      const categories = await this.prisma.category.findMany({ select: { id: true, name: true } });
+      const categoryNames = categories.map((c) => c.name);
+
       const base64 = imageBuffer.toString('base64');
       const dataUrl = `data:${mimetype};base64,${base64}`;
 
@@ -41,12 +54,12 @@ export class AiService {
             {
               role: 'user',
               content: [
-                { type: 'text', text: ANALYZE_PROMPT },
+                { type: 'text', text: buildPrompt(categoryNames) },
                 { type: 'image_url', image_url: { url: dataUrl } },
               ],
             },
           ],
-          max_tokens: 256,
+          max_tokens: 512,
           response_format: { type: 'json_object' },
           temperature: 0,
         },
@@ -57,7 +70,13 @@ export class AiService {
       const parsed = JSON.parse(raw) as Record<string, unknown>;
 
       const name = typeof parsed.name === 'string' ? parsed.name.trim() : '';
-      const category = typeof parsed.category === 'string' ? parsed.category.trim() : '';
+      const categoryRaw =
+        parsed.category === null
+          ? null
+          : typeof parsed.category === 'string'
+            ? parsed.category.trim() || null
+            : null;
+      const description = typeof parsed.description === 'string' ? parsed.description.trim() : '';
       const price_min =
         typeof parsed.price_min === 'number' || typeof parsed.price_min === 'string'
           ? Number(parsed.price_min)
@@ -67,11 +86,25 @@ export class AiService {
           ? Number(parsed.price_max)
           : NaN;
 
-      if (!name || !category || !isFinite(price_min) || !isFinite(price_max)) {
+      if (!name || !description || !isFinite(price_min) || !isFinite(price_max)) {
         throw new Error(`Invalid AI response shape: ${raw}`);
       }
 
-      const result: AnalyzeResult = { name, category, price_min, price_max };
+      const matched = categoryRaw
+        ? categories.find((c) => c.name.toLowerCase() === categoryRaw.toLowerCase())
+        : undefined;
+
+      const category = matched ? matched.name : categoryRaw;
+      const category_id = matched ? matched.id : null;
+
+      const result: AnalyzeResult = {
+        name,
+        category,
+        category_id,
+        description,
+        price_min,
+        price_max,
+      };
 
       if (result.price_min > result.price_max) {
         [result.price_min, result.price_max] = [result.price_max, result.price_min];

--- a/src/modules/ai/ai.service.ts
+++ b/src/modules/ai/ai.service.ts
@@ -40,10 +40,19 @@ export class AiService {
   }
 
   async analyze(imageBuffer: Buffer, mimetype: string): Promise<AnalyzeResult> {
-    try {
-      const categories = await this.prisma.category.findMany({ select: { id: true, name: true } });
-      const categoryNames = categories.map((c) => c.name);
+    let categories: Array<{ id: string; name: string }>;
 
+    try {
+      categories = await this.prisma.category.findMany({ select: { id: true, name: true } });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Category lookup failed: ${message}`, err instanceof Error ? err.stack : undefined);
+      throw new ServiceUnavailableException('Category lookup failed');
+    }
+
+    const categoryNames = categories.map((c) => c.name);
+
+    try {
       const base64 = imageBuffer.toString('base64');
       const dataUrl = `data:${mimetype};base64,${base64}`;
 

--- a/src/modules/ai/ai.service.ts
+++ b/src/modules/ai/ai.service.ts
@@ -4,16 +4,16 @@ import { PrismaService } from '../prisma/prisma.service';
 import OpenAI from 'openai';
 
 function buildPrompt(categoryNames: string[]): string {
-  const list = categoryNames.join(', ');
+  const list = JSON.stringify(categoryNames);
   return `Analyze the image and return a JSON object with the following fields:
 - name: item name in Portuguese (Brazil)
-- category: pick the single most fitting category from this list, or null if none fit: [${list}]
+- category: pick the single most fitting category from this list, or null if none fit: ${list}
 - description: brief item description in one paragraph, in Portuguese (Brazil)
 - price_min: minimum market value in BRL (number)
 - price_max: maximum market value in BRL (number)
 
 Return only valid JSON, no explanation:
-{ "name": "", "category": "", "description": "", "price_min": 0, "price_max": 0 }`;
+{ "name": "", "category": null, "description": "", "price_min": 0, "price_max": 0 }`;
 }
 
 export interface AnalyzeResult {
@@ -94,7 +94,7 @@ export class AiService {
         ? categories.find((c) => c.name.toLowerCase() === categoryRaw.toLowerCase())
         : undefined;
 
-      const category = matched ? matched.name : categoryRaw;
+      const category = matched ? matched.name : null;
       const category_id = matched ? matched.id : null;
 
       const result: AnalyzeResult = {


### PR DESCRIPTION
Closes #27

## What changed

- `AiService` now injects `PrismaService` and fetches all categories before calling OpenAI, injecting the category name list into the prompt dynamically
- The prompt asks the model to pick a category from the list (or return `null`) and to provide a one-paragraph item `description` in Portuguese (Brazil)
- `AnalyzeResult` gains `description: string`, `category_id: string | null`; `category` is now `string | null` — after the AI responds, `category_id` is resolved via case-insensitive match against the fetched categories
- Tests updated: mocks `PrismaService.category.findMany`, covers matched category, case-insensitive match, null category, unrecognized category, prompt content, price swap, and error cases

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (8/8)
- [ ] Manual: POST /ai/analyze with a real image returns `description`, `category`, and `category_id`