### PR TITLE
feat: GET /categories endpoint to fetch all categories

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -524,6 +524,32 @@
       ]
     },
     {
+      "name": "Categories",
+      "item": [
+        {
+          "name": "GET /categories",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/categories",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "categories"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "AI",
       "item": [
         {

--- a/docs/api.md
+++ b/docs/api.md
@@ -144,7 +144,20 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 }
 ```
 
-> **Categories** are read-only reference data. No `GET /categories` endpoint is exposed — seed the DB with `npm run prisma:seed` to populate them. Use a seeded category's `id` as `category_id` in item requests.
+---
+
+## Categories <Badge type="tip" text="Implemented" />
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | /categories | List all categories ordered alphabetically |
+
+```json
+// GET /categories — response 200
+[{ "id": "uuid", "name": "string" }]
+```
+
+> All routes require JWT authentication. Seed categories with `npm run prisma:seed`.
 
 ---
 

--- a/src/modules/items/categories.controller.spec.ts
+++ b/src/modules/items/categories.controller.spec.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { CategoriesController } from './categories.controller';
+import { ItemsService } from './items.service';
+
+describe('CategoriesController', () => {
+  let controller: CategoriesController;
+
+  const mockItemsService = {
+    findAllCategories: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriesController],
+      providers: [{ provide: ItemsService, useValue: mockItemsService }],
+    }).compile();
+
+    controller = module.get<CategoriesController>(CategoriesController);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('delegates to itemsService.findAllCategories and returns its result', async () => {
+      const categories = [
+        { id: 'cat-1', name: 'Eletrônicos' },
+        { id: 'cat-2', name: 'Móveis' },
+      ];
+      mockItemsService.findAllCategories.mockResolvedValue(categories);
+
+      const result = await controller.findAll();
+
+      expect(mockItemsService.findAllCategories).toHaveBeenCalledTimes(1);
+      expect(result).toBe(categories);
+    });
+
+    it('returns empty array when no categories exist', async () => {
+      mockItemsService.findAllCategories.mockResolvedValue([]);
+
+      const result = await controller.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, CategoriesController.prototype.findAll);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/items/categories.controller.ts
+++ b/src/modules/items/categories.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { ItemsService } from './items.service';
+
+@Controller('categories')
+export class CategoriesController {
+  constructor(private readonly itemsService: ItemsService) {}
+
+  @Get()
+  findAll() {
+    return this.itemsService.findAllCategories();
+  }
+}

--- a/src/modules/items/items.module.ts
+++ b/src/modules/items/items.module.ts
@@ -1,5 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { ItemsController } from './items.controller';
+import { CategoriesController } from './categories.controller';
 import { ItemsService } from './items.service';
 import { ItemsRepository } from './items.repository';
 import { ListsModule } from '../lists/lists.module';
@@ -7,7 +8,7 @@ import { StorageModule } from '../storage/storage.module';
 
 @Module({
   imports: [forwardRef(() => ListsModule), StorageModule],
-  controllers: [ItemsController],
+  controllers: [ItemsController, CategoriesController],
   providers: [ItemsService, ItemsRepository],
   exports: [ItemsService],
 })

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -96,6 +96,10 @@ export class ItemsRepository {
     return result.count;
   }
 
+  findAllCategories() {
+    return this.prisma.category.findMany({ orderBy: { name: 'asc' } });
+  }
+
   searchByUser(userId: string, search: string) {
     return this.prisma.item.findMany({
       where: {

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -83,6 +83,7 @@ describe('ItemsService', () => {
             delete: jest.fn(),
             searchByUser: jest.fn(),
             findByList: jest.fn(),
+            findAllCategories: jest.fn(),
           },
         },
         {
@@ -182,7 +183,9 @@ describe('ItemsService', () => {
     it('includes category object in response when category_id is provided', async () => {
       const category = { id: '00000000-0000-0000-0000-000000000001', name: 'Eletrônicos' };
       listsRepository.findOneByUser.mockResolvedValue(mockList);
-      itemsRepository.create.mockResolvedValue(makeItem({ category_id: category.id, category }) as any);
+      itemsRepository.create.mockResolvedValue(
+        makeItem({ category_id: category.id, category }) as any,
+      );
 
       const result = await service.create('user-1', { ...dto, category_id: category.id });
 
@@ -305,7 +308,9 @@ describe('ItemsService', () => {
   describe('search', () => {
     it('delegates to repository with userId and query and returns mapped response', async () => {
       const createdAt = new Date();
-      itemsRepository.searchByUser.mockResolvedValue([makeItem({ name: 'vintage lamp', created_at: createdAt })] as any);
+      itemsRepository.searchByUser.mockResolvedValue([
+        makeItem({ name: 'vintage lamp', created_at: createdAt }),
+      ] as any);
 
       const result = await service.search('user-1', 'lamp');
 
@@ -338,6 +343,29 @@ describe('ItemsService', () => {
       itemsRepository.searchByUser.mockResolvedValue([]);
 
       const result = await service.search('user-1', 'nonexistent');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findAllCategories', () => {
+    it('delegates to repository and returns result as-is', async () => {
+      const categories = [
+        { id: 'cat-1', name: 'Eletrônicos' },
+        { id: 'cat-2', name: 'Móveis' },
+      ];
+      itemsRepository.findAllCategories.mockResolvedValue(categories as any);
+
+      const result = await service.findAllCategories();
+
+      expect(itemsRepository.findAllCategories).toHaveBeenCalledTimes(1);
+      expect(result).toBe(categories);
+    });
+
+    it('returns empty array when no categories exist', async () => {
+      itemsRepository.findAllCategories.mockResolvedValue([]);
+
+      const result = await service.findAllCategories();
 
       expect(result).toEqual([]);
     });

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -130,6 +130,10 @@ export class ItemsService {
     }
   }
 
+  findAllCategories() {
+    return this.repository.findAllCategories();
+  }
+
   async search(userId: string, query: string) {
     const items = await this.repository.searchByUser(userId, query);
     return items.map((item) => this.mapItem(item));


### PR DESCRIPTION
Closes #29

## What changed

- Added `findAllCategories()` to `ItemsRepository` (queries `category` table ordered by name) and `ItemsService` (delegates to repository)
- Created `CategoriesController` at `GET /categories` — JWT-protected, returns `[{ id, name }]`
- Registered `CategoriesController` in `ItemsModule`
- Added unit tests for service and controller; updated Postman collection with a `GET /categories` request

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (103 tests, 11 suites)
- [ ] Manual: `GET /categories` with valid JWT returns alphabetically-ordered category list
- [ ] Manual: `GET /categories` without JWT returns 401