### PR TITLE
feat: list color and icon selection

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -193,6 +193,50 @@
       "name": "Lists",
       "item": [
         {
+          "name": "GET /lists/colors",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/lists/colors",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "lists",
+                "colors"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET /lists/icons",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/lists/icons",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "lists",
+                "icons"
+              ]
+            }
+          }
+        },
+        {
           "name": "GET /lists",
           "request": {
             "method": "GET",
@@ -229,7 +273,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"My First List\",\n  \"location\": \"123 Main St\"\n}"
+              "raw": "{\n  \"name\": \"My First List\",\n  \"location\": \"123 Main St\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000005\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000002\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/lists",
@@ -258,7 +302,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Renamed List\",\n  \"location\": \"456 Oak Ave\"\n}"
+              "raw": "{\n  \"name\": \"Updated List Name\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000004\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000003\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/lists/:id",
@@ -308,7 +352,7 @@
                 {
                   "key": "limit",
                   "value": "20",
-                  "description": "Page size (1–100, default 20)"
+                  "description": "Page size (1\u2013100, default 20)"
                 }
               ],
               "variable": [
@@ -427,7 +471,7 @@
                   "key": "image",
                   "type": "file",
                   "src": "/path/to/image.jpg",
-                  "description": "Optional main image (JPEG, PNG, WebP, GIF — max 10 MB)",
+                  "description": "Optional main image (JPEG, PNG, WebP, GIF \u2014 max 10 MB)",
                   "disabled": true
                 }
               ]
@@ -475,7 +519,7 @@
                   "key": "image",
                   "type": "file",
                   "src": "/path/to/new-image.jpg",
-                  "description": "Optional replacement main image (JPEG, PNG, WebP, GIF — max 10 MB)",
+                  "description": "Optional replacement main image (JPEG, PNG, WebP, GIF \u2014 max 10 MB)",
                   "disabled": true
                 }
               ]
@@ -611,7 +655,7 @@
                   "key": "image",
                   "type": "file",
                   "src": "/path/to/image.jpg",
-                  "description": "Image file to analyze (JPEG, PNG, WebP, GIF — max 10 MB)"
+                  "description": "Image file to analyze (JPEG, PNG, WebP, GIF \u2014 max 10 MB)"
                 }
               ]
             },

--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -237,6 +237,28 @@
           }
         },
         {
+          "name": "GET /lists/pictures",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/lists/pictures",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "lists",
+                "pictures"
+              ]
+            }
+          }
+        },
+        {
           "name": "GET /lists",
           "request": {
             "method": "GET",
@@ -273,7 +295,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"My First List\",\n  \"location\": \"123 Main St\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000005\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000002\"\n}"
+              "raw": "{\n  \"name\": \"My First List\",\n  \"location\": \"123 Main St\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000005\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000002\",\n  \"picture_id\": \"00000000-0000-0000-0000-000000000001\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/lists",
@@ -302,7 +324,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated List Name\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000004\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000003\"\n}"
+              "raw": "{\n  \"name\": \"Updated List Name\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000004\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000003\",\n  \"picture_id\": \"00000000-0000-0000-0000-000000000002\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/lists/:id",

--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -295,7 +295,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"My First List\",\n  \"location\": \"123 Main St\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000005\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000002\",\n  \"picture_id\": \"00000000-0000-0000-0000-000000000001\"\n}"
+              "raw": "{\n  \"name\": \"My First List\",\n  \"location\": \"123 Main St\",\n  \"color_id\": \"#3B82F6\",\n  \"icon_id\": \"shopping-cart\",\n  \"picture_id\": \"beach_house\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/lists",
@@ -324,7 +324,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated List Name\",\n  \"color_id\": \"00000000-0000-0000-0000-000000000004\",\n  \"icon_id\": \"00000000-0000-0000-0000-000000000003\",\n  \"picture_id\": \"00000000-0000-0000-0000-000000000002\"\n}"
+              "raw": "{\n  \"name\": \"Updated List Name\",\n  \"color_id\": \"#22C55E\",\n  \"icon_id\": \"home\",\n  \"picture_id\": \"country_house\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/lists/:id",

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 |--------|----------|-------------|
 | GET | /lists/colors | All available list colors (ordered) |
 | GET | /lists/icons | All available list icons (ordered) |
+| GET | /lists/pictures | All available list pictures (ordered) |
 | GET | /lists | All lists for authenticated user |
 | GET | /lists/:id/items | Paginated items for a specific list |
 | POST | /lists | Create list |
@@ -59,19 +60,22 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 // GET /lists/icons — response 200
 [{ "id": "uuid", "name": "string", "slug": "string", "order": 0 }]
 
+// GET /lists/pictures — response 200
+[{ "id": "uuid", "slug": "string", "order": 0 }]
+
 // POST /lists — request
-{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid" }
-// location optional; color_id and icon_id required
+{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid", "picture_id": "uuid" }
+// location optional; color_id, icon_id, picture_id required
 
 // PATCH /lists/:id — request
-{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid" }
-// location, color_id, icon_id all optional
+{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid", "picture_id": "uuid" }
+// location, color_id, icon_id, picture_id all optional
 
 // PATCH /lists/:id — response 200
-{ "id": "uuid", "name": "string", "location": "string | null", "color_id": "uuid", "icon_id": "uuid", "created_at": "timestamp" }
+{ "id": "uuid", "name": "string", "location": "string | null", "color_id": "uuid", "icon_id": "uuid", "picture_id": "uuid", "created_at": "timestamp" }
 
 // GET /lists — response 200
-[{ "id": "uuid", "name": "string", "location": "string | null", "color": { "id": "uuid", "name": "string", "hex_code": "#rrggbb", "order": 0 }, "icon": { "id": "uuid", "name": "string", "slug": "string", "order": 0 }, "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
+[{ "id": "uuid", "name": "string", "location": "string | null", "color": { "id": "uuid", "name": "string", "hex_code": "#rrggbb", "order": 0 }, "icon": { "id": "uuid", "name": "string", "slug": "string", "order": 0 }, "picture": { "id": "uuid", "slug": "string", "order": 0 }, "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
 
 // GET /lists/:id/items — query params
 // cursor?: uuid   — ID of the last item seen (omit for first page)

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,27 +55,27 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 ```json
 // GET /lists/colors — response 200
-[{ "id": "uuid", "name": "string", "hex_code": "#rrggbb", "order": 0 }]
+[{ "hex_code": "#rrggbb", "name": "string", "order": 0 }]
 
 // GET /lists/icons — response 200
-[{ "id": "uuid", "name": "string", "slug": "string", "order": 0 }]
+[{ "slug": "string", "name": "string", "order": 0 }]
 
 // GET /lists/pictures — response 200
-[{ "id": "uuid", "slug": "string", "order": 0 }]
+[{ "slug": "string", "order": 0 }]
 
 // POST /lists — request
-{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid", "picture_id": "uuid" }
-// location optional; color_id, icon_id, picture_id required
+{ "name": "string", "location": "string", "color_id": "#rrggbb", "icon_id": "slug", "picture_id": "slug" }
+// location optional; color_id (hex), icon_id (slug), picture_id (slug) required
 
 // PATCH /lists/:id — request
-{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid", "picture_id": "uuid" }
+{ "name": "string", "location": "string", "color_id": "#rrggbb", "icon_id": "slug", "picture_id": "slug" }
 // location, color_id, icon_id, picture_id all optional
 
 // PATCH /lists/:id — response 200
-{ "id": "uuid", "name": "string", "location": "string | null", "color_id": "uuid", "icon_id": "uuid", "picture_id": "uuid", "created_at": "timestamp" }
+{ "id": "uuid", "name": "string", "location": "string | null", "color_id": "#rrggbb", "icon_id": "slug", "picture_id": "slug", "created_at": "timestamp" }
 
 // GET /lists — response 200
-[{ "id": "uuid", "name": "string", "location": "string | null", "color": { "id": "uuid", "name": "string", "hex_code": "#rrggbb", "order": 0 }, "icon": { "id": "uuid", "name": "string", "slug": "string", "order": 0 }, "picture": { "id": "uuid", "slug": "string", "order": 0 }, "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
+[{ "id": "uuid", "name": "string", "location": "string | null", "color": { "hex_code": "#rrggbb", "name": "string", "order": 0 }, "icon": { "slug": "string", "name": "string", "order": 0 }, "picture": { "slug": "string", "order": 0 }, "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
 
 // GET /lists/:id/items — query params
 // cursor?: uuid   — ID of the last item seen (omit for first page)

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,24 +44,34 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
+| GET | /lists/colors | All available list colors (ordered) |
+| GET | /lists/icons | All available list icons (ordered) |
 | GET | /lists | All lists for authenticated user |
 | GET | /lists/:id/items | Paginated items for a specific list |
 | POST | /lists | Create list |
-| PATCH | /lists/:id | Rename list |
+| PATCH | /lists/:id | Update list |
 | DELETE | /lists/:id | Delete list and all its items |
 
 ```json
+// GET /lists/colors — response 200
+[{ "id": "uuid", "name": "string", "hex_code": "#rrggbb", "order": 0 }]
+
+// GET /lists/icons — response 200
+[{ "id": "uuid", "name": "string", "slug": "string", "order": 0 }]
+
 // POST /lists — request
-{ "name": "string", "location": "string" }   // location optional
+{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid" }
+// location optional; color_id and icon_id required
 
 // PATCH /lists/:id — request
-{ "name": "string", "location": "string" }   // location optional
+{ "name": "string", "location": "string", "color_id": "uuid", "icon_id": "uuid" }
+// location, color_id, icon_id all optional
 
 // PATCH /lists/:id — response 200
-{ "id": "uuid", "name": "string", "location": "string | null", "created_at": "timestamp" }
+{ "id": "uuid", "name": "string", "location": "string | null", "color_id": "uuid", "icon_id": "uuid", "created_at": "timestamp" }
 
 // GET /lists — response 200
-[{ "id": "uuid", "name": "string", "location": "string | null", "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
+[{ "id": "uuid", "name": "string", "location": "string | null", "color": { "id": "uuid", "name": "string", "hex_code": "#rrggbb", "order": 0 }, "icon": { "id": "uuid", "name": "string", "slug": "string", "order": 0 }, "item_count": 0, "total_value": 0, "created_at": "timestamp" }]
 
 // GET /lists/:id/items — query params
 // cursor?: uuid   — ID of the last item seen (omit for first page)

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -21,9 +21,8 @@ Global reference data — seeded on `prisma:seed`. Controls the color palette av
 
 | Field | Type | Notes |
 |-------|------|-------|
-| id | uuid | PK |
-| name | string | unique; e.g. "Vermelho", "Azul" |
-| hex_code | string | CSS hex color, e.g. `#EF4444` |
+| hex_code | string | PK; CSS hex color, e.g. `#EF4444` |
+| name | string | unique; human-readable name, e.g. "Vermelho" |
 | order | integer | display order in the palette; default 0 |
 
 ## ListIcon
@@ -32,9 +31,8 @@ Global reference data — seeded on `prisma:seed`. Controls the icon set availab
 
 | Field | Type | Notes |
 |-------|------|-------|
-| id | uuid | PK |
+| slug | string | PK; icon key for the frontend, e.g. `shopping-cart` |
 | name | string | unique; human-readable name, e.g. "Carrinho" |
-| slug | string | unique; icon key for the frontend, e.g. `shopping-cart` |
 | order | integer | display order in the picker; default 0 |
 
 ## ListPicture
@@ -43,8 +41,7 @@ Global reference data — seeded on `prisma:seed`. Controls the picture set avai
 
 | Field | Type | Notes |
 |-------|------|-------|
-| id | uuid | PK |
-| slug | string | unique; asset key for the frontend, e.g. `beach_house` |
+| slug | string | PK; asset key for the frontend, e.g. `beach_house` |
 | order | integer | display order in the picker; default 0 |
 
 ## List

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -37,6 +37,16 @@ Global reference data — seeded on `prisma:seed`. Controls the icon set availab
 | slug | string | unique; icon key for the frontend, e.g. `shopping-cart` |
 | order | integer | display order in the picker; default 0 |
 
+## ListPicture
+
+Global reference data — seeded on `prisma:seed`. Controls the picture set available when creating or editing a list. The frontend resolves slugs to image assets.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | uuid | PK |
+| slug | string | unique; asset key for the frontend, e.g. `beach_house` |
+| order | integer | display order in the picker; default 0 |
+
 ## List
 
 | Field | Type | Notes |
@@ -47,6 +57,7 @@ Global reference data — seeded on `prisma:seed`. Controls the icon set availab
 | location | string | nullable, plain text address |
 | color_id | uuid | FK → list_colors; non-nullable |
 | icon_id | uuid | FK → list_icons; non-nullable |
+| picture_id | uuid | FK → list_pictures; non-nullable |
 | created_at | timestamp | |
 
 ## Item

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -52,9 +52,9 @@ Global reference data — seeded on `prisma:seed`. Controls the picture set avai
 | user_id | uuid | FK → users |
 | name | string | |
 | location | string | nullable, plain text address |
-| color_id | uuid | FK → list_colors; non-nullable |
-| icon_id | uuid | FK → list_icons; non-nullable |
-| picture_id | uuid | FK → list_pictures; non-nullable |
+| color | string | FK → list_colors (hex_code); non-nullable |
+| icon | string | FK → list_icons (slug); non-nullable |
+| picture | string | FK → list_pictures (slug); non-nullable |
 | created_at | timestamp | |
 
 ## Item

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -15,6 +15,28 @@
 | tier | string | `"free"` or `"premium"`; default `"free"`. Updated by RevenueCat webhooks and login reconciliation. |
 | created_at | timestamp | |
 
+## ListColor
+
+Global reference data — seeded on `prisma:seed`. Controls the color palette available when creating or editing a list.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | uuid | PK |
+| name | string | unique; e.g. "Vermelho", "Azul" |
+| hex_code | string | CSS hex color, e.g. `#EF4444` |
+| order | integer | display order in the palette; default 0 |
+
+## ListIcon
+
+Global reference data — seeded on `prisma:seed`. Controls the icon set available when creating or editing a list.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | uuid | PK |
+| name | string | unique; human-readable name, e.g. "Carrinho" |
+| slug | string | unique; icon key for the frontend, e.g. `shopping-cart` |
+| order | integer | display order in the picker; default 0 |
+
 ## List
 
 | Field | Type | Notes |
@@ -23,6 +45,8 @@
 | user_id | uuid | FK → users |
 | name | string | |
 | location | string | nullable, plain text address |
+| color_id | uuid | FK → list_colors; non-nullable |
+| icon_id | uuid | FK → list_icons; non-nullable |
 | created_at | timestamp | |
 
 ## Item

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,7 @@
 - [x] Global item search (`GET /items?search=`)
 - [x] Paginated items by list (`GET /lists/:id/items` — cursor-based)
 - [x] Category reference table with seeded Portuguese values; `category_id` on items
+- [x] List color and icon selection (`GET /lists/colors`, `GET /lists/icons`; `color_id`/`icon_id` on lists)
 
 ## Milestone 3 — Image Upload + Storage <Badge type="tip" text="Implemented" />
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,6 +18,7 @@
 - [x] Paginated items by list (`GET /lists/:id/items` — cursor-based)
 - [x] Category reference table with seeded Portuguese values; `category_id` on items
 - [x] List color and icon selection (`GET /lists/colors`, `GET /lists/icons`; `color_id`/`icon_id` on lists)
+- [x] List picture selection (`GET /lists/pictures`; `picture_id` on lists; slug-based, 4 seeded presets)
 
 ## Milestone 3 — Image Upload + Storage <Badge type="tip" text="Implemented" />
 

--- a/prisma/migrations/20260422000000_add_list_color_icon/migration.sql
+++ b/prisma/migrations/20260422000000_add_list_color_icon/migration.sql
@@ -1,56 +1,53 @@
--- Create list_colors table
+-- Create list_colors table (hex_code as PK)
 CREATE TABLE "list_colors" (
-  "id"       TEXT NOT NULL,
-  "name"     TEXT NOT NULL,
   "hex_code" TEXT NOT NULL,
+  "name"     TEXT NOT NULL,
   "order"    INTEGER NOT NULL DEFAULT 0,
-  CONSTRAINT "list_colors_pkey" PRIMARY KEY ("id")
+  CONSTRAINT "list_colors_pkey" PRIMARY KEY ("hex_code")
 );
 CREATE UNIQUE INDEX "list_colors_name_key" ON "list_colors"("name");
 
--- Create list_icons table
+-- Create list_icons table (slug as PK)
 CREATE TABLE "list_icons" (
-  "id"    TEXT NOT NULL,
-  "name"  TEXT NOT NULL,
   "slug"  TEXT NOT NULL,
+  "name"  TEXT NOT NULL,
   "order" INTEGER NOT NULL DEFAULT 0,
-  CONSTRAINT "list_icons_pkey" PRIMARY KEY ("id")
+  CONSTRAINT "list_icons_pkey" PRIMARY KEY ("slug")
 );
 CREATE UNIQUE INDEX "list_icons_name_key" ON "list_icons"("name");
-CREATE UNIQUE INDEX "list_icons_slug_key" ON "list_icons"("slug");
 
--- Insert default color and icon with fixed UUIDs
-INSERT INTO "list_colors" ("id", "name", "hex_code", "order")
-VALUES ('00000000-0000-0000-0000-000000000001', 'Vermelho', '#EF4444', 0)
-ON CONFLICT ("name") DO NOTHING;
+-- Insert default color and icon
+INSERT INTO "list_colors" ("hex_code", "name", "order")
+VALUES ('#EF4444', 'Vermelho', 0)
+ON CONFLICT ("hex_code") DO NOTHING;
 
-INSERT INTO "list_icons" ("id", "name", "slug", "order")
-VALUES ('00000000-0000-0000-0000-000000000001', 'Lista', 'list', 0)
-ON CONFLICT ("name") DO NOTHING;
+INSERT INTO "list_icons" ("slug", "name", "order")
+VALUES ('list', 'Lista', 0)
+ON CONFLICT ("slug") DO NOTHING;
 
--- Add color_id and icon_id as nullable with defaults pointing to the seeded rows
+-- Add color_id and icon_id as nullable with defaults
 ALTER TABLE "lists"
-  ADD COLUMN "color_id" TEXT DEFAULT '00000000-0000-0000-0000-000000000001',
-  ADD COLUMN "icon_id"  TEXT DEFAULT '00000000-0000-0000-0000-000000000001';
+  ADD COLUMN "color_id" TEXT DEFAULT '#EF4444',
+  ADD COLUMN "icon_id"  TEXT DEFAULT 'list';
 
--- Back-fill any NULLs (safety net for existing rows)
+-- Back-fill existing rows
 UPDATE "lists"
 SET
-  "color_id" = '00000000-0000-0000-0000-000000000001',
-  "icon_id"  = '00000000-0000-0000-0000-000000000001'
+  "color_id" = '#EF4444',
+  "icon_id"  = 'list'
 WHERE "color_id" IS NULL OR "icon_id" IS NULL;
 
 -- Make columns NOT NULL
 ALTER TABLE "lists" ALTER COLUMN "color_id" SET NOT NULL;
 ALTER TABLE "lists" ALTER COLUMN "icon_id"  SET NOT NULL;
 
--- Drop the DEFAULT (Prisma manages defaults at the application layer)
+-- Drop the DEFAULT
 ALTER TABLE "lists" ALTER COLUMN "color_id" DROP DEFAULT;
 ALTER TABLE "lists" ALTER COLUMN "icon_id"  DROP DEFAULT;
 
 -- Add FK constraints
 ALTER TABLE "lists"
-  ADD CONSTRAINT "lists_color_id_fkey" FOREIGN KEY ("color_id") REFERENCES "list_colors"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT "lists_color_id_fkey" FOREIGN KEY ("color_id") REFERENCES "list_colors"("hex_code") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 ALTER TABLE "lists"
-  ADD CONSTRAINT "lists_icon_id_fkey" FOREIGN KEY ("icon_id") REFERENCES "list_icons"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT "lists_icon_id_fkey" FOREIGN KEY ("icon_id") REFERENCES "list_icons"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260422000000_add_list_color_icon/migration.sql
+++ b/prisma/migrations/20260422000000_add_list_color_icon/migration.sql
@@ -25,29 +25,29 @@ INSERT INTO "list_icons" ("slug", "name", "order")
 VALUES ('list', 'Lista', 0)
 ON CONFLICT ("slug") DO NOTHING;
 
--- Add color_id and icon_id as nullable with defaults
+-- Add color and icon as nullable with defaults
 ALTER TABLE "lists"
-  ADD COLUMN "color_id" TEXT DEFAULT '#EF4444',
-  ADD COLUMN "icon_id"  TEXT DEFAULT 'list';
+  ADD COLUMN "color" TEXT DEFAULT '#EF4444',
+  ADD COLUMN "icon"  TEXT DEFAULT 'list';
 
 -- Back-fill existing rows
 UPDATE "lists"
 SET
-  "color_id" = '#EF4444',
-  "icon_id"  = 'list'
-WHERE "color_id" IS NULL OR "icon_id" IS NULL;
+  "color" = '#EF4444',
+  "icon"  = 'list'
+WHERE "color" IS NULL OR "icon" IS NULL;
 
 -- Make columns NOT NULL
-ALTER TABLE "lists" ALTER COLUMN "color_id" SET NOT NULL;
-ALTER TABLE "lists" ALTER COLUMN "icon_id"  SET NOT NULL;
+ALTER TABLE "lists" ALTER COLUMN "color" SET NOT NULL;
+ALTER TABLE "lists" ALTER COLUMN "icon"  SET NOT NULL;
 
 -- Drop the DEFAULT
-ALTER TABLE "lists" ALTER COLUMN "color_id" DROP DEFAULT;
-ALTER TABLE "lists" ALTER COLUMN "icon_id"  DROP DEFAULT;
+ALTER TABLE "lists" ALTER COLUMN "color" DROP DEFAULT;
+ALTER TABLE "lists" ALTER COLUMN "icon"  DROP DEFAULT;
 
 -- Add FK constraints
 ALTER TABLE "lists"
-  ADD CONSTRAINT "lists_color_id_fkey" FOREIGN KEY ("color_id") REFERENCES "list_colors"("hex_code") ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT "lists_color_fkey" FOREIGN KEY ("color") REFERENCES "list_colors"("hex_code") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 ALTER TABLE "lists"
-  ADD CONSTRAINT "lists_icon_id_fkey" FOREIGN KEY ("icon_id") REFERENCES "list_icons"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT "lists_icon_fkey" FOREIGN KEY ("icon") REFERENCES "list_icons"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260422000000_add_list_color_icon/migration.sql
+++ b/prisma/migrations/20260422000000_add_list_color_icon/migration.sql
@@ -1,0 +1,56 @@
+-- Create list_colors table
+CREATE TABLE "list_colors" (
+  "id"       TEXT NOT NULL,
+  "name"     TEXT NOT NULL,
+  "hex_code" TEXT NOT NULL,
+  "order"    INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT "list_colors_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "list_colors_name_key" ON "list_colors"("name");
+
+-- Create list_icons table
+CREATE TABLE "list_icons" (
+  "id"    TEXT NOT NULL,
+  "name"  TEXT NOT NULL,
+  "slug"  TEXT NOT NULL,
+  "order" INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT "list_icons_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "list_icons_name_key" ON "list_icons"("name");
+CREATE UNIQUE INDEX "list_icons_slug_key" ON "list_icons"("slug");
+
+-- Insert default color and icon with fixed UUIDs
+INSERT INTO "list_colors" ("id", "name", "hex_code", "order")
+VALUES ('00000000-0000-0000-0000-000000000001', 'Vermelho', '#EF4444', 0)
+ON CONFLICT ("name") DO NOTHING;
+
+INSERT INTO "list_icons" ("id", "name", "slug", "order")
+VALUES ('00000000-0000-0000-0000-000000000001', 'Lista', 'list', 0)
+ON CONFLICT ("name") DO NOTHING;
+
+-- Add color_id and icon_id as nullable with defaults pointing to the seeded rows
+ALTER TABLE "lists"
+  ADD COLUMN "color_id" TEXT DEFAULT '00000000-0000-0000-0000-000000000001',
+  ADD COLUMN "icon_id"  TEXT DEFAULT '00000000-0000-0000-0000-000000000001';
+
+-- Back-fill any NULLs (safety net for existing rows)
+UPDATE "lists"
+SET
+  "color_id" = '00000000-0000-0000-0000-000000000001',
+  "icon_id"  = '00000000-0000-0000-0000-000000000001'
+WHERE "color_id" IS NULL OR "icon_id" IS NULL;
+
+-- Make columns NOT NULL
+ALTER TABLE "lists" ALTER COLUMN "color_id" SET NOT NULL;
+ALTER TABLE "lists" ALTER COLUMN "icon_id"  SET NOT NULL;
+
+-- Drop the DEFAULT (Prisma manages defaults at the application layer)
+ALTER TABLE "lists" ALTER COLUMN "color_id" DROP DEFAULT;
+ALTER TABLE "lists" ALTER COLUMN "icon_id"  DROP DEFAULT;
+
+-- Add FK constraints
+ALTER TABLE "lists"
+  ADD CONSTRAINT "lists_color_id_fkey" FOREIGN KEY ("color_id") REFERENCES "list_colors"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "lists"
+  ADD CONSTRAINT "lists_icon_id_fkey" FOREIGN KEY ("icon_id") REFERENCES "list_icons"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260422000001_add_list_picture/migration.sql
+++ b/prisma/migrations/20260422000001_add_list_picture/migration.sql
@@ -1,24 +1,22 @@
--- Create list_pictures table
+-- Create list_pictures table (slug as PK)
 CREATE TABLE "list_pictures" (
-  "id"    TEXT NOT NULL,
   "slug"  TEXT NOT NULL,
   "order" INTEGER NOT NULL DEFAULT 0,
-  CONSTRAINT "list_pictures_pkey" PRIMARY KEY ("id")
+  CONSTRAINT "list_pictures_pkey" PRIMARY KEY ("slug")
 );
-CREATE UNIQUE INDEX "list_pictures_slug_key" ON "list_pictures"("slug");
 
--- Insert default picture with a fixed UUID
-INSERT INTO "list_pictures" ("id", "slug", "order")
-VALUES ('00000000-0000-0000-0000-000000000001', 'storage', 0)
+-- Insert default picture
+INSERT INTO "list_pictures" ("slug", "order")
+VALUES ('storage', 0)
 ON CONFLICT ("slug") DO NOTHING;
 
--- Add picture_id as nullable with the default pointing to the seeded row
+-- Add picture_id as nullable with default
 ALTER TABLE "lists"
-  ADD COLUMN "picture_id" TEXT DEFAULT '00000000-0000-0000-0000-000000000001';
+  ADD COLUMN "picture_id" TEXT DEFAULT 'storage';
 
--- Back-fill any NULLs
+-- Back-fill existing rows
 UPDATE "lists"
-SET "picture_id" = '00000000-0000-0000-0000-000000000001'
+SET "picture_id" = 'storage'
 WHERE "picture_id" IS NULL;
 
 -- Make column NOT NULL
@@ -29,4 +27,4 @@ ALTER TABLE "lists" ALTER COLUMN "picture_id" DROP DEFAULT;
 
 -- Add FK constraint
 ALTER TABLE "lists"
-  ADD CONSTRAINT "lists_picture_id_fkey" FOREIGN KEY ("picture_id") REFERENCES "list_pictures"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT "lists_picture_id_fkey" FOREIGN KEY ("picture_id") REFERENCES "list_pictures"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260422000001_add_list_picture/migration.sql
+++ b/prisma/migrations/20260422000001_add_list_picture/migration.sql
@@ -10,21 +10,21 @@ INSERT INTO "list_pictures" ("slug", "order")
 VALUES ('storage', 0)
 ON CONFLICT ("slug") DO NOTHING;
 
--- Add picture_id as nullable with default
+-- Add picture as nullable with default
 ALTER TABLE "lists"
-  ADD COLUMN "picture_id" TEXT DEFAULT 'storage';
+  ADD COLUMN "picture" TEXT DEFAULT 'storage';
 
 -- Back-fill existing rows
 UPDATE "lists"
-SET "picture_id" = 'storage'
-WHERE "picture_id" IS NULL;
+SET "picture" = 'storage'
+WHERE "picture" IS NULL;
 
 -- Make column NOT NULL
-ALTER TABLE "lists" ALTER COLUMN "picture_id" SET NOT NULL;
+ALTER TABLE "lists" ALTER COLUMN "picture" SET NOT NULL;
 
 -- Drop the DEFAULT
-ALTER TABLE "lists" ALTER COLUMN "picture_id" DROP DEFAULT;
+ALTER TABLE "lists" ALTER COLUMN "picture" DROP DEFAULT;
 
 -- Add FK constraint
 ALTER TABLE "lists"
-  ADD CONSTRAINT "lists_picture_id_fkey" FOREIGN KEY ("picture_id") REFERENCES "list_pictures"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;
+  ADD CONSTRAINT "lists_picture_fkey" FOREIGN KEY ("picture") REFERENCES "list_pictures"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260422000001_add_list_picture/migration.sql
+++ b/prisma/migrations/20260422000001_add_list_picture/migration.sql
@@ -1,0 +1,32 @@
+-- Create list_pictures table
+CREATE TABLE "list_pictures" (
+  "id"    TEXT NOT NULL,
+  "slug"  TEXT NOT NULL,
+  "order" INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT "list_pictures_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "list_pictures_slug_key" ON "list_pictures"("slug");
+
+-- Insert default picture with a fixed UUID
+INSERT INTO "list_pictures" ("id", "slug", "order")
+VALUES ('00000000-0000-0000-0000-000000000001', 'storage', 0)
+ON CONFLICT ("slug") DO NOTHING;
+
+-- Add picture_id as nullable with the default pointing to the seeded row
+ALTER TABLE "lists"
+  ADD COLUMN "picture_id" TEXT DEFAULT '00000000-0000-0000-0000-000000000001';
+
+-- Back-fill any NULLs
+UPDATE "lists"
+SET "picture_id" = '00000000-0000-0000-0000-000000000001'
+WHERE "picture_id" IS NULL;
+
+-- Make column NOT NULL
+ALTER TABLE "lists" ALTER COLUMN "picture_id" SET NOT NULL;
+
+-- Drop the DEFAULT
+ALTER TABLE "lists" ALTER COLUMN "picture_id" DROP DEFAULT;
+
+-- Add FK constraint
+ALTER TABLE "lists"
+  ADD CONSTRAINT "lists_picture_id_fkey" FOREIGN KEY ("picture_id") REFERENCES "list_pictures"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,9 +54,8 @@ model ProcessedWebhookEvent {
 }
 
 model ListColor {
-  id       String @id @default(uuid())
+  hex_code String @id
   name     String @unique
-  hex_code String
   order    Int    @default(0)
   lists    List[]
 
@@ -64,9 +63,8 @@ model ListColor {
 }
 
 model ListIcon {
-  id    String @id @default(uuid())
+  slug  String @id
   name  String @unique
-  slug  String @unique
   order Int    @default(0)
   lists List[]
 
@@ -74,8 +72,7 @@ model ListIcon {
 }
 
 model ListPicture {
-  id    String @id @default(uuid())
-  slug  String @unique
+  slug  String @id
   order Int    @default(0)
   lists List[]
 
@@ -93,9 +90,9 @@ model List {
   created_at DateTime @default(now()) @map("created_at")
 
   user    User        @relation(fields: [user_id], references: [id], onDelete: Cascade)
-  color   ListColor   @relation(fields: [color_id], references: [id])
-  icon    ListIcon    @relation(fields: [icon_id], references: [id])
-  picture ListPicture @relation(fields: [picture_id], references: [id])
+  color   ListColor   @relation(fields: [color_id], references: [hex_code])
+  icon    ListIcon    @relation(fields: [icon_id], references: [slug])
+  picture ListPicture @relation(fields: [picture_id], references: [slug])
   items   Item[]
 
   @@index([user_id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,15 @@ model ListIcon {
   @@map("list_icons")
 }
 
+model ListPicture {
+  id    String @id @default(uuid())
+  slug  String @unique
+  order Int    @default(0)
+  lists List[]
+
+  @@map("list_pictures")
+}
+
 model List {
   id         String   @id @default(uuid())
   user_id    String
@@ -80,12 +89,14 @@ model List {
   location   String?
   color_id   String
   icon_id    String
+  picture_id String
   created_at DateTime @default(now()) @map("created_at")
 
-  user  User      @relation(fields: [user_id], references: [id], onDelete: Cascade)
-  color ListColor @relation(fields: [color_id], references: [id])
-  icon  ListIcon  @relation(fields: [icon_id], references: [id])
-  items Item[]
+  user    User        @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  color   ListColor   @relation(fields: [color_id], references: [id])
+  icon    ListIcon    @relation(fields: [icon_id], references: [id])
+  picture ListPicture @relation(fields: [picture_id], references: [id])
+  items   Item[]
 
   @@index([user_id])
   @@map("lists")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,9 +84,9 @@ model List {
   user_id    String
   name       String
   location   String?
-  color_id   String
-  icon_id    String
-  picture_id String
+  color_id   String @map("color")
+  icon_id    String @map("icon")
+  picture_id String @map("picture")
   created_at DateTime @default(now()) @map("created_at")
 
   user    User        @relation(fields: [user_id], references: [id], onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,14 +53,38 @@ model ProcessedWebhookEvent {
   @@map("processed_webhook_events")
 }
 
+model ListColor {
+  id       String @id @default(uuid())
+  name     String @unique
+  hex_code String
+  order    Int    @default(0)
+  lists    List[]
+
+  @@map("list_colors")
+}
+
+model ListIcon {
+  id    String @id @default(uuid())
+  name  String @unique
+  slug  String @unique
+  order Int    @default(0)
+  lists List[]
+
+  @@map("list_icons")
+}
+
 model List {
   id         String   @id @default(uuid())
   user_id    String
   name       String
   location   String?
+  color_id   String
+  icon_id    String
   created_at DateTime @default(now()) @map("created_at")
 
-  user  User   @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user  User      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  color ListColor @relation(fields: [color_id], references: [id])
+  icon  ListIcon  @relation(fields: [icon_id], references: [id])
   items Item[]
 
   @@index([user_id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,6 +23,30 @@ const categories = [
   'Outros',
 ];
 
+const listColors = [
+  { id: '00000000-0000-0000-0000-000000000001', name: 'Vermelho', hex_code: '#EF4444', order: 0 },
+  { id: '00000000-0000-0000-0000-000000000002', name: 'Laranja', hex_code: '#F97316', order: 1 },
+  { id: '00000000-0000-0000-0000-000000000003', name: 'Amarelo', hex_code: '#EAB308', order: 2 },
+  { id: '00000000-0000-0000-0000-000000000004', name: 'Verde', hex_code: '#22C55E', order: 3 },
+  { id: '00000000-0000-0000-0000-000000000005', name: 'Azul', hex_code: '#3B82F6', order: 4 },
+  { id: '00000000-0000-0000-0000-000000000006', name: 'Roxo', hex_code: '#A855F7', order: 5 },
+  { id: '00000000-0000-0000-0000-000000000007', name: 'Rosa', hex_code: '#EC4899', order: 6 },
+  { id: '00000000-0000-0000-0000-000000000008', name: 'Cinza', hex_code: '#6B7280', order: 7 },
+];
+
+const listIcons = [
+  { id: '00000000-0000-0000-0000-000000000001', name: 'Lista', slug: 'list', order: 0 },
+  { id: '00000000-0000-0000-0000-000000000002', name: 'Carrinho', slug: 'shopping-cart', order: 1 },
+  { id: '00000000-0000-0000-0000-000000000003', name: 'Casa', slug: 'home', order: 2 },
+  { id: '00000000-0000-0000-0000-000000000004', name: 'Presente', slug: 'gift', order: 3 },
+  { id: '00000000-0000-0000-0000-000000000005', name: 'Etiqueta', slug: 'tag', order: 4 },
+  { id: '00000000-0000-0000-0000-000000000006', name: 'Maleta', slug: 'briefcase', order: 5 },
+  { id: '00000000-0000-0000-0000-000000000007', name: 'Coração', slug: 'heart', order: 6 },
+  { id: '00000000-0000-0000-0000-000000000008', name: 'Estrela', slug: 'star', order: 7 },
+  { id: '00000000-0000-0000-0000-000000000009', name: 'Livro', slug: 'book', order: 8 },
+  { id: '00000000-0000-0000-0000-000000000010', name: 'Ferramenta', slug: 'tool', order: 9 },
+];
+
 async function main() {
   for (const name of categories) {
     await prisma.category.upsert({
@@ -32,6 +56,24 @@ async function main() {
     });
   }
   console.log(`Seeded ${categories.length} categories.`);
+
+  for (const color of listColors) {
+    await prisma.listColor.upsert({
+      where: { name: color.name },
+      update: { hex_code: color.hex_code, order: color.order },
+      create: color,
+    });
+  }
+  console.log(`Seeded ${listColors.length} list colors.`);
+
+  for (const icon of listIcons) {
+    await prisma.listIcon.upsert({
+      where: { name: icon.name },
+      update: { slug: icon.slug, order: icon.order },
+      create: icon,
+    });
+  }
+  console.log(`Seeded ${listIcons.length} list icons.`);
 }
 
 main()

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -47,6 +47,13 @@ const listIcons = [
   { id: '00000000-0000-0000-0000-000000000010', name: 'Ferramenta', slug: 'tool', order: 9 },
 ];
 
+const listPictures = [
+  { id: '00000000-0000-0000-0000-000000000001', slug: 'storage', order: 0 },
+  { id: '00000000-0000-0000-0000-000000000002', slug: 'beach_house', order: 1 },
+  { id: '00000000-0000-0000-0000-000000000003', slug: 'country_house', order: 2 },
+  { id: '00000000-0000-0000-0000-000000000004', slug: 'assets', order: 3 },
+];
+
 async function main() {
   for (const name of categories) {
     await prisma.category.upsert({
@@ -74,6 +81,15 @@ async function main() {
     });
   }
   console.log(`Seeded ${listIcons.length} list icons.`);
+
+  for (const picture of listPictures) {
+    await prisma.listPicture.upsert({
+      where: { slug: picture.slug },
+      update: { order: picture.order },
+      create: picture,
+    });
+  }
+  console.log(`Seeded ${listPictures.length} list pictures.`);
 }
 
 main()

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -24,34 +24,34 @@ const categories = [
 ];
 
 const listColors = [
-  { id: '00000000-0000-0000-0000-000000000001', name: 'Vermelho', hex_code: '#EF4444', order: 0 },
-  { id: '00000000-0000-0000-0000-000000000002', name: 'Laranja', hex_code: '#F97316', order: 1 },
-  { id: '00000000-0000-0000-0000-000000000003', name: 'Amarelo', hex_code: '#EAB308', order: 2 },
-  { id: '00000000-0000-0000-0000-000000000004', name: 'Verde', hex_code: '#22C55E', order: 3 },
-  { id: '00000000-0000-0000-0000-000000000005', name: 'Azul', hex_code: '#3B82F6', order: 4 },
-  { id: '00000000-0000-0000-0000-000000000006', name: 'Roxo', hex_code: '#A855F7', order: 5 },
-  { id: '00000000-0000-0000-0000-000000000007', name: 'Rosa', hex_code: '#EC4899', order: 6 },
-  { id: '00000000-0000-0000-0000-000000000008', name: 'Cinza', hex_code: '#6B7280', order: 7 },
+  { hex_code: '#EF4444', name: 'Vermelho', order: 0 },
+  { hex_code: '#F97316', name: 'Laranja', order: 1 },
+  { hex_code: '#EAB308', name: 'Amarelo', order: 2 },
+  { hex_code: '#22C55E', name: 'Verde', order: 3 },
+  { hex_code: '#3B82F6', name: 'Azul', order: 4 },
+  { hex_code: '#A855F7', name: 'Roxo', order: 5 },
+  { hex_code: '#EC4899', name: 'Rosa', order: 6 },
+  { hex_code: '#6B7280', name: 'Cinza', order: 7 },
 ];
 
 const listIcons = [
-  { id: '00000000-0000-0000-0000-000000000001', name: 'Lista', slug: 'list', order: 0 },
-  { id: '00000000-0000-0000-0000-000000000002', name: 'Carrinho', slug: 'shopping-cart', order: 1 },
-  { id: '00000000-0000-0000-0000-000000000003', name: 'Casa', slug: 'home', order: 2 },
-  { id: '00000000-0000-0000-0000-000000000004', name: 'Presente', slug: 'gift', order: 3 },
-  { id: '00000000-0000-0000-0000-000000000005', name: 'Etiqueta', slug: 'tag', order: 4 },
-  { id: '00000000-0000-0000-0000-000000000006', name: 'Maleta', slug: 'briefcase', order: 5 },
-  { id: '00000000-0000-0000-0000-000000000007', name: 'Coração', slug: 'heart', order: 6 },
-  { id: '00000000-0000-0000-0000-000000000008', name: 'Estrela', slug: 'star', order: 7 },
-  { id: '00000000-0000-0000-0000-000000000009', name: 'Livro', slug: 'book', order: 8 },
-  { id: '00000000-0000-0000-0000-000000000010', name: 'Ferramenta', slug: 'tool', order: 9 },
+  { slug: 'list', name: 'Lista', order: 0 },
+  { slug: 'shopping-cart', name: 'Carrinho', order: 1 },
+  { slug: 'home', name: 'Casa', order: 2 },
+  { slug: 'gift', name: 'Presente', order: 3 },
+  { slug: 'tag', name: 'Etiqueta', order: 4 },
+  { slug: 'briefcase', name: 'Maleta', order: 5 },
+  { slug: 'heart', name: 'Coração', order: 6 },
+  { slug: 'star', name: 'Estrela', order: 7 },
+  { slug: 'book', name: 'Livro', order: 8 },
+  { slug: 'tool', name: 'Ferramenta', order: 9 },
 ];
 
 const listPictures = [
-  { id: '00000000-0000-0000-0000-000000000001', slug: 'storage', order: 0 },
-  { id: '00000000-0000-0000-0000-000000000002', slug: 'beach_house', order: 1 },
-  { id: '00000000-0000-0000-0000-000000000003', slug: 'country_house', order: 2 },
-  { id: '00000000-0000-0000-0000-000000000004', slug: 'assets', order: 3 },
+  { slug: 'storage', order: 0 },
+  { slug: 'beach_house', order: 1 },
+  { slug: 'country_house', order: 2 },
+  { slug: 'assets', order: 3 },
 ];
 
 async function main() {
@@ -66,8 +66,8 @@ async function main() {
 
   for (const color of listColors) {
     await prisma.listColor.upsert({
-      where: { name: color.name },
-      update: { hex_code: color.hex_code, order: color.order },
+      where: { hex_code: color.hex_code },
+      update: { name: color.name, order: color.order },
       create: color,
     });
   }
@@ -75,8 +75,8 @@ async function main() {
 
   for (const icon of listIcons) {
     await prisma.listIcon.upsert({
-      where: { name: icon.name },
-      update: { slug: icon.slug, order: icon.order },
+      where: { slug: icon.slug },
+      update: { name: icon.name, order: icon.order },
       create: icon,
     });
   }

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -44,9 +44,9 @@ const mockList = {
   user_id: 'user-1',
   name: 'My List',
   location: null,
-  color_id: 'color-1',
-  icon_id: 'icon-1',
-  picture_id: 'pic-1',
+  color_id: '#EF4444',
+  icon_id: 'list',
+  picture_id: 'storage',
   created_at: new Date(),
 };
 

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -46,6 +46,7 @@ const mockList = {
   location: null,
   color_id: 'color-1',
   icon_id: 'icon-1',
+  picture_id: 'pic-1',
   created_at: new Date(),
 };
 

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -44,6 +44,8 @@ const mockList = {
   user_id: 'user-1',
   name: 'My List',
   location: null,
+  color_id: 'color-1',
+  icon_id: 'icon-1',
   created_at: new Date(),
 };
 

--- a/src/modules/lists/dto/create-list.dto.ts
+++ b/src/modules/lists/dto/create-list.dto.ts
@@ -10,6 +10,7 @@ export class CreateListDto {
   location?: string;
 
   @IsHexColor()
+  @IsNotEmpty()
   color_id: string;
 
   @IsString()

--- a/src/modules/lists/dto/create-list.dto.ts
+++ b/src/modules/lists/dto/create-list.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsHexColor, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateListDto {
   @IsString()
@@ -9,12 +9,14 @@ export class CreateListDto {
   @IsOptional()
   location?: string;
 
-  @IsUUID()
+  @IsHexColor()
   color_id: string;
 
-  @IsUUID()
+  @IsString()
+  @IsNotEmpty()
   icon_id: string;
 
-  @IsUUID()
+  @IsString()
+  @IsNotEmpty()
   picture_id: string;
 }

--- a/src/modules/lists/dto/create-list.dto.ts
+++ b/src/modules/lists/dto/create-list.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class CreateListDto {
   @IsString()
@@ -8,4 +8,10 @@ export class CreateListDto {
   @IsString()
   @IsOptional()
   location?: string;
+
+  @IsUUID()
+  color_id: string;
+
+  @IsUUID()
+  icon_id: string;
 }

--- a/src/modules/lists/dto/create-list.dto.ts
+++ b/src/modules/lists/dto/create-list.dto.ts
@@ -14,4 +14,7 @@ export class CreateListDto {
 
   @IsUUID()
   icon_id: string;
+
+  @IsUUID()
+  picture_id: string;
 }

--- a/src/modules/lists/dto/update-list.dto.ts
+++ b/src/modules/lists/dto/update-list.dto.ts
@@ -16,4 +16,8 @@ export class UpdateListDto {
   @IsUUID()
   @IsOptional()
   icon_id?: string;
+
+  @IsUUID()
+  @IsOptional()
+  picture_id?: string;
 }

--- a/src/modules/lists/dto/update-list.dto.ts
+++ b/src/modules/lists/dto/update-list.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsHexColor, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class UpdateListDto {
   @IsString()
@@ -9,15 +9,17 @@ export class UpdateListDto {
   @IsOptional()
   location?: string;
 
-  @IsUUID()
+  @IsHexColor()
   @IsOptional()
   color_id?: string;
 
-  @IsUUID()
+  @IsString()
+  @IsNotEmpty()
   @IsOptional()
   icon_id?: string;
 
-  @IsUUID()
+  @IsString()
+  @IsNotEmpty()
   @IsOptional()
   picture_id?: string;
 }

--- a/src/modules/lists/dto/update-list.dto.ts
+++ b/src/modules/lists/dto/update-list.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class UpdateListDto {
   @IsString()
@@ -8,4 +8,12 @@ export class UpdateListDto {
   @IsString()
   @IsOptional()
   location?: string;
+
+  @IsUUID()
+  @IsOptional()
+  color_id?: string;
+
+  @IsUUID()
+  @IsOptional()
+  icon_id?: string;
 }

--- a/src/modules/lists/lists.controller.spec.ts
+++ b/src/modules/lists/lists.controller.spec.ts
@@ -11,6 +11,7 @@ describe('ListsController', () => {
   const mockListsService = {
     getColors: jest.fn(),
     getIcons: jest.fn(),
+    getPictures: jest.fn(),
     getAll: jest.fn(),
     create: jest.fn(),
     rename: jest.fn(),
@@ -70,6 +71,23 @@ describe('ListsController', () => {
     });
   });
 
+  describe('getPictures', () => {
+    it('delegates to listsService.getPictures', async () => {
+      const pictures = [{ id: 'pic-1', slug: 'storage', order: 0 }];
+      mockListsService.getPictures.mockResolvedValue(pictures);
+
+      const result = await controller.getPictures();
+
+      expect(mockListsService.getPictures).toHaveBeenCalled();
+      expect(result).toBe(pictures);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ListsController.prototype.getPictures);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
   describe('getAll', () => {
     it('delegates to listsService.getAll with userId from req.user.id', async () => {
       const expected = [
@@ -91,7 +109,7 @@ describe('ListsController', () => {
 
   describe('create', () => {
     it('delegates to listsService.create with userId and dto', async () => {
-      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1' };
+      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1', picture_id: 'pic-1' };
       const expected = {
         id: 'list-1',
         name: 'New List',

--- a/src/modules/lists/lists.controller.spec.ts
+++ b/src/modules/lists/lists.controller.spec.ts
@@ -9,6 +9,8 @@ describe('ListsController', () => {
   let controller: ListsController;
 
   const mockListsService = {
+    getColors: jest.fn(),
+    getIcons: jest.fn(),
     getAll: jest.fn(),
     create: jest.fn(),
     rename: jest.fn(),
@@ -34,6 +36,40 @@ describe('ListsController', () => {
 
   const makeReq = (id: string) => ({ user: { id } }) as any;
 
+  describe('getColors', () => {
+    it('delegates to listsService.getColors', async () => {
+      const colors = [{ id: 'color-1', name: 'Vermelho', hex_code: '#EF4444', order: 0 }];
+      mockListsService.getColors.mockResolvedValue(colors);
+
+      const result = await controller.getColors();
+
+      expect(mockListsService.getColors).toHaveBeenCalled();
+      expect(result).toBe(colors);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ListsController.prototype.getColors);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
+  describe('getIcons', () => {
+    it('delegates to listsService.getIcons', async () => {
+      const icons = [{ id: 'icon-1', name: 'Lista', slug: 'list', order: 0 }];
+      mockListsService.getIcons.mockResolvedValue(icons);
+
+      const result = await controller.getIcons();
+
+      expect(mockListsService.getIcons).toHaveBeenCalled();
+      expect(result).toBe(icons);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, ListsController.prototype.getIcons);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+
   describe('getAll', () => {
     it('delegates to listsService.getAll with userId from req.user.id', async () => {
       const expected = [
@@ -55,7 +91,7 @@ describe('ListsController', () => {
 
   describe('create', () => {
     it('delegates to listsService.create with userId and dto', async () => {
-      const dto = { name: 'New List' };
+      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1' };
       const expected = {
         id: 'list-1',
         name: 'New List',

--- a/src/modules/lists/lists.controller.spec.ts
+++ b/src/modules/lists/lists.controller.spec.ts
@@ -39,7 +39,7 @@ describe('ListsController', () => {
 
   describe('getColors', () => {
     it('delegates to listsService.getColors', async () => {
-      const colors = [{ id: 'color-1', name: 'Vermelho', hex_code: '#EF4444', order: 0 }];
+      const colors = [{ hex_code: '#EF4444', name: 'Vermelho', order: 0 }];
       mockListsService.getColors.mockResolvedValue(colors);
 
       const result = await controller.getColors();
@@ -56,7 +56,7 @@ describe('ListsController', () => {
 
   describe('getIcons', () => {
     it('delegates to listsService.getIcons', async () => {
-      const icons = [{ id: 'icon-1', name: 'Lista', slug: 'list', order: 0 }];
+      const icons = [{ slug: 'list', name: 'Lista', order: 0 }];
       mockListsService.getIcons.mockResolvedValue(icons);
 
       const result = await controller.getIcons();
@@ -73,7 +73,7 @@ describe('ListsController', () => {
 
   describe('getPictures', () => {
     it('delegates to listsService.getPictures', async () => {
-      const pictures = [{ id: 'pic-1', slug: 'storage', order: 0 }];
+      const pictures = [{ slug: 'storage', order: 0 }];
       mockListsService.getPictures.mockResolvedValue(pictures);
 
       const result = await controller.getPictures();
@@ -109,7 +109,7 @@ describe('ListsController', () => {
 
   describe('create', () => {
     it('delegates to listsService.create with userId and dto', async () => {
-      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1', picture_id: 'pic-1' };
+      const dto = { name: 'New List', color_id: '#EF4444', icon_id: 'list', picture_id: 'storage' };
       const expected = {
         id: 'list-1',
         name: 'New List',

--- a/src/modules/lists/lists.controller.ts
+++ b/src/modules/lists/lists.controller.ts
@@ -35,6 +35,11 @@ export class ListsController {
     return this.listsService.getIcons();
   }
 
+  @Get('pictures')
+  getPictures() {
+    return this.listsService.getPictures();
+  }
+
   @Get()
   getAll(@Req() req: Request) {
     const user = req.user as { id: string };

--- a/src/modules/lists/lists.controller.ts
+++ b/src/modules/lists/lists.controller.ts
@@ -25,6 +25,16 @@ export class ListsController {
     private readonly itemsService: ItemsService,
   ) {}
 
+  @Get('colors')
+  getColors() {
+    return this.listsService.getColors();
+  }
+
+  @Get('icons')
+  getIcons() {
+    return this.listsService.getIcons();
+  }
+
   @Get()
   getAll(@Req() req: Request) {
     const user = req.user as { id: string };

--- a/src/modules/lists/lists.repository.ts
+++ b/src/modules/lists/lists.repository.ts
@@ -8,10 +8,18 @@ import { Prisma } from '../../generated/prisma/client';
 export class ListsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  findAllColors() {
+    return this.prisma.listColor.findMany({ orderBy: { order: 'asc' } });
+  }
+
+  findAllIcons() {
+    return this.prisma.listIcon.findMany({ orderBy: { order: 'asc' } });
+  }
+
   async findAllByUser(userId: string) {
     const lists = await this.prisma.list.findMany({
       where: { user_id: userId },
-      include: { _count: { select: { items: true } } },
+      include: { _count: { select: { items: true } }, color: true, icon: true },
       orderBy: { created_at: 'desc' },
     });
 
@@ -36,7 +44,13 @@ export class ListsRepository {
   create(userId: string, dto: CreateListDto, tx?: Prisma.TransactionClient) {
     const client = tx ?? this.prisma;
     return client.list.create({
-      data: { user_id: userId, name: dto.name, location: dto.location },
+      data: {
+        user_id: userId,
+        name: dto.name,
+        location: dto.location,
+        color_id: dto.color_id,
+        icon_id: dto.icon_id,
+      },
     });
   }
 
@@ -50,6 +64,8 @@ export class ListsRepository {
       data: {
         name: dto.name,
         ...(dto.location !== undefined && { location: dto.location }),
+        ...(dto.color_id !== undefined && { color_id: dto.color_id }),
+        ...(dto.icon_id !== undefined && { icon_id: dto.icon_id }),
       },
     });
     if (result.count === 0) return null;

--- a/src/modules/lists/lists.repository.ts
+++ b/src/modules/lists/lists.repository.ts
@@ -16,10 +16,14 @@ export class ListsRepository {
     return this.prisma.listIcon.findMany({ orderBy: { order: 'asc' } });
   }
 
+  findAllPictures() {
+    return this.prisma.listPicture.findMany({ orderBy: { order: 'asc' } });
+  }
+
   async findAllByUser(userId: string) {
     const lists = await this.prisma.list.findMany({
       where: { user_id: userId },
-      include: { _count: { select: { items: true } }, color: true, icon: true },
+      include: { _count: { select: { items: true } }, color: true, icon: true, picture: true },
       orderBy: { created_at: 'desc' },
     });
 
@@ -50,6 +54,7 @@ export class ListsRepository {
         location: dto.location,
         color_id: dto.color_id,
         icon_id: dto.icon_id,
+        picture_id: dto.picture_id,
       },
     });
   }
@@ -66,6 +71,7 @@ export class ListsRepository {
         ...(dto.location !== undefined && { location: dto.location }),
         ...(dto.color_id !== undefined && { color_id: dto.color_id }),
         ...(dto.icon_id !== undefined && { icon_id: dto.icon_id }),
+        ...(dto.picture_id !== undefined && { picture_id: dto.picture_id }),
       },
     });
     if (result.count === 0) return null;

--- a/src/modules/lists/lists.service.spec.ts
+++ b/src/modules/lists/lists.service.spec.ts
@@ -7,6 +7,9 @@ import { LimitsService } from '../tiers/limits.service';
 describe('ListsService', () => {
   let service: ListsService;
   let repository: jest.Mocked<ListsRepository>;
+
+  const defaultColor = { id: 'color-1', name: 'Vermelho', hex_code: '#EF4444', order: 0 };
+  const defaultIcon = { id: 'icon-1', name: 'Lista', slug: 'list', order: 0 };
   let limits: { withListCapLock: jest.Mock };
 
   beforeEach(async () => {
@@ -24,6 +27,8 @@ describe('ListsService', () => {
         {
           provide: ListsRepository,
           useValue: {
+            findAllColors: jest.fn(),
+            findAllIcons: jest.fn(),
             findAllByUser: jest.fn(),
             create: jest.fn(),
             update: jest.fn(),
@@ -39,6 +44,30 @@ describe('ListsService', () => {
 
     service = module.get<ListsService>(ListsService);
     repository = module.get(ListsRepository);
+  });
+
+  describe('getColors', () => {
+    it('delegates to repository.findAllColors', async () => {
+      const colors = [defaultColor];
+      repository.findAllColors.mockResolvedValue(colors);
+
+      const result = await service.getColors();
+
+      expect(repository.findAllColors).toHaveBeenCalled();
+      expect(result).toBe(colors);
+    });
+  });
+
+  describe('getIcons', () => {
+    it('delegates to repository.findAllIcons', async () => {
+      const icons = [defaultIcon];
+      repository.findAllIcons.mockResolvedValue(icons);
+
+      const result = await service.getIcons();
+
+      expect(repository.findAllIcons).toHaveBeenCalled();
+      expect(result).toBe(icons);
+    });
   });
 
   describe('getAll', () => {
@@ -57,6 +86,10 @@ describe('ListsService', () => {
           name: 'My List',
           location: null,
           user_id: 'user-1',
+          color_id: 'color-1',
+          icon_id: 'icon-1',
+          color: defaultColor,
+          icon: defaultIcon,
           created_at: new Date('2026-01-01'),
           _count: { items: 2 },
           total_value: 15.5,
@@ -80,6 +113,10 @@ describe('ListsService', () => {
           name: 'My List',
           location: null,
           user_id: 'user-1',
+          color_id: 'color-1',
+          icon_id: 'icon-1',
+          color: defaultColor,
+          icon: defaultIcon,
           created_at: new Date('2026-01-01'),
           _count: { items: 0 },
           total_value: 0,
@@ -98,9 +135,9 @@ describe('ListsService', () => {
         new ForbiddenException({ code: 'LIMIT_REACHED', limit: 3 }),
       );
 
-      await expect(service.create('user-1', { name: 'New List' })).rejects.toThrow(
-        ForbiddenException,
-      );
+      await expect(
+        service.create('user-1', { name: 'New List', color_id: 'color-1', icon_id: 'icon-1' }),
+      ).rejects.toThrow(ForbiddenException);
       expect(repository.create).not.toHaveBeenCalled();
     });
 
@@ -109,17 +146,22 @@ describe('ListsService', () => {
         id: 'list-1',
         name: 'New List',
         location: null,
+        color_id: 'color-1',
+        icon_id: 'icon-1',
         user_id: 'user-1',
         created_at: new Date('2026-01-01'),
       });
 
-      const result = await service.create('user-1', { name: 'New List' });
+      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1' };
+      const result = await service.create('user-1', dto);
 
-      expect(repository.create).toHaveBeenCalledWith('user-1', { name: 'New List' }, undefined);
+      expect(repository.create).toHaveBeenCalledWith('user-1', dto, undefined);
       expect(result).toEqual({
         id: 'list-1',
         name: 'New List',
         location: null,
+        color_id: 'color-1',
+        icon_id: 'icon-1',
         item_count: 0,
         total_value: 0,
         created_at: new Date('2026-01-01'),
@@ -131,17 +173,21 @@ describe('ListsService', () => {
         id: 'list-2',
         name: 'Garage',
         location: '123 Main St',
+        color_id: 'color-1',
+        icon_id: 'icon-1',
         user_id: 'user-1',
         created_at: new Date('2026-01-01'),
       });
 
-      const result = await service.create('user-1', { name: 'Garage', location: '123 Main St' });
+      const dto = {
+        name: 'Garage',
+        location: '123 Main St',
+        color_id: 'color-1',
+        icon_id: 'icon-1',
+      };
+      const result = await service.create('user-1', dto);
 
-      expect(repository.create).toHaveBeenCalledWith(
-        'user-1',
-        { name: 'Garage', location: '123 Main St' },
-        undefined,
-      );
+      expect(repository.create).toHaveBeenCalledWith('user-1', dto, undefined);
       expect(result.location).toBe('123 Main St');
     });
   });
@@ -153,6 +199,8 @@ describe('ListsService', () => {
         user_id: 'user-1',
         name: 'Updated Name',
         location: null,
+        color_id: 'color-1',
+        icon_id: 'icon-1',
         created_at: new Date('2026-01-01'),
       });
 
@@ -168,6 +216,8 @@ describe('ListsService', () => {
         user_id: 'user-1',
         name: 'My List',
         location: '456 Oak Ave',
+        color_id: 'color-1',
+        icon_id: 'icon-1',
         created_at: new Date('2026-01-01'),
       });
 

--- a/src/modules/lists/lists.service.spec.ts
+++ b/src/modules/lists/lists.service.spec.ts
@@ -8,9 +8,9 @@ describe('ListsService', () => {
   let service: ListsService;
   let repository: jest.Mocked<ListsRepository>;
 
-  const defaultColor = { id: 'color-1', name: 'Vermelho', hex_code: '#EF4444', order: 0 };
-  const defaultIcon = { id: 'icon-1', name: 'Lista', slug: 'list', order: 0 };
-  const defaultPicture = { id: 'pic-1', slug: 'storage', order: 0 };
+  const defaultColor = { hex_code: '#EF4444', name: 'Vermelho', order: 0 };
+  const defaultIcon = { slug: 'list', name: 'Lista', order: 0 };
+  const defaultPicture = { slug: 'storage', order: 0 };
   let limits: { withListCapLock: jest.Mock };
 
   beforeEach(async () => {
@@ -100,9 +100,9 @@ describe('ListsService', () => {
           name: 'My List',
           location: null,
           user_id: 'user-1',
-          color_id: 'color-1',
-          icon_id: 'icon-1',
-          picture_id: 'pic-1',
+          color_id: '#EF4444',
+          icon_id: 'list',
+          picture_id: 'storage',
           color: defaultColor,
           icon: defaultIcon,
           picture: defaultPicture,
@@ -129,9 +129,9 @@ describe('ListsService', () => {
           name: 'My List',
           location: null,
           user_id: 'user-1',
-          color_id: 'color-1',
-          icon_id: 'icon-1',
-          picture_id: 'pic-1',
+          color_id: '#EF4444',
+          icon_id: 'list',
+          picture_id: 'storage',
           color: defaultColor,
           icon: defaultIcon,
           picture: defaultPicture,
@@ -156,9 +156,9 @@ describe('ListsService', () => {
       await expect(
         service.create('user-1', {
           name: 'New List',
-          color_id: 'color-1',
-          icon_id: 'icon-1',
-          picture_id: 'pic-1',
+          color_id: '#EF4444',
+          icon_id: 'list',
+          picture_id: 'storage',
         }),
       ).rejects.toThrow(ForbiddenException);
       expect(repository.create).not.toHaveBeenCalled();
@@ -169,14 +169,14 @@ describe('ListsService', () => {
         id: 'list-1',
         name: 'New List',
         location: null,
-        color_id: 'color-1',
-        icon_id: 'icon-1',
-        picture_id: 'pic-1',
+        color_id: '#EF4444',
+        icon_id: 'list',
+        picture_id: 'storage',
         user_id: 'user-1',
         created_at: new Date('2026-01-01'),
       });
 
-      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1', picture_id: 'pic-1' };
+      const dto = { name: 'New List', color_id: '#EF4444', icon_id: 'list', picture_id: 'pic-1' };
       const result = await service.create('user-1', dto);
 
       expect(repository.create).toHaveBeenCalledWith('user-1', dto, undefined);
@@ -184,9 +184,9 @@ describe('ListsService', () => {
         id: 'list-1',
         name: 'New List',
         location: null,
-        color_id: 'color-1',
-        icon_id: 'icon-1',
-        picture_id: 'pic-1',
+        color_id: '#EF4444',
+        icon_id: 'list',
+        picture_id: 'storage',
         item_count: 0,
         total_value: 0,
         created_at: new Date('2026-01-01'),
@@ -198,9 +198,9 @@ describe('ListsService', () => {
         id: 'list-2',
         name: 'Garage',
         location: '123 Main St',
-        color_id: 'color-1',
-        icon_id: 'icon-1',
-        picture_id: 'pic-1',
+        color_id: '#EF4444',
+        icon_id: 'list',
+        picture_id: 'storage',
         user_id: 'user-1',
         created_at: new Date('2026-01-01'),
       });
@@ -208,9 +208,9 @@ describe('ListsService', () => {
       const dto = {
         name: 'Garage',
         location: '123 Main St',
-        color_id: 'color-1',
-        icon_id: 'icon-1',
-        picture_id: 'pic-1',
+        color_id: '#EF4444',
+        icon_id: 'list',
+        picture_id: 'storage',
       };
       const result = await service.create('user-1', dto);
 
@@ -226,9 +226,9 @@ describe('ListsService', () => {
         user_id: 'user-1',
         name: 'Updated Name',
         location: null,
-        color_id: 'color-1',
-        icon_id: 'icon-1',
-        picture_id: 'pic-1',
+        color_id: '#EF4444',
+        icon_id: 'list',
+        picture_id: 'storage',
         created_at: new Date('2026-01-01'),
       });
 
@@ -244,9 +244,9 @@ describe('ListsService', () => {
         user_id: 'user-1',
         name: 'My List',
         location: '456 Oak Ave',
-        color_id: 'color-1',
-        icon_id: 'icon-1',
-        picture_id: 'pic-1',
+        color_id: '#EF4444',
+        icon_id: 'list',
+        picture_id: 'storage',
         created_at: new Date('2026-01-01'),
       });
 

--- a/src/modules/lists/lists.service.spec.ts
+++ b/src/modules/lists/lists.service.spec.ts
@@ -10,6 +10,7 @@ describe('ListsService', () => {
 
   const defaultColor = { id: 'color-1', name: 'Vermelho', hex_code: '#EF4444', order: 0 };
   const defaultIcon = { id: 'icon-1', name: 'Lista', slug: 'list', order: 0 };
+  const defaultPicture = { id: 'pic-1', slug: 'storage', order: 0 };
   let limits: { withListCapLock: jest.Mock };
 
   beforeEach(async () => {
@@ -29,6 +30,7 @@ describe('ListsService', () => {
           useValue: {
             findAllColors: jest.fn(),
             findAllIcons: jest.fn(),
+            findAllPictures: jest.fn(),
             findAllByUser: jest.fn(),
             create: jest.fn(),
             update: jest.fn(),
@@ -70,6 +72,18 @@ describe('ListsService', () => {
     });
   });
 
+  describe('getPictures', () => {
+    it('delegates to repository.findAllPictures', async () => {
+      const pictures = [defaultPicture];
+      repository.findAllPictures.mockResolvedValue(pictures);
+
+      const result = await service.getPictures();
+
+      expect(repository.findAllPictures).toHaveBeenCalled();
+      expect(result).toBe(pictures);
+    });
+  });
+
   describe('getAll', () => {
     it('returns empty array when user has no lists', async () => {
       repository.findAllByUser.mockResolvedValue([]);
@@ -88,8 +102,10 @@ describe('ListsService', () => {
           user_id: 'user-1',
           color_id: 'color-1',
           icon_id: 'icon-1',
+          picture_id: 'pic-1',
           color: defaultColor,
           icon: defaultIcon,
+          picture: defaultPicture,
           created_at: new Date('2026-01-01'),
           _count: { items: 2 },
           total_value: 15.5,
@@ -115,8 +131,10 @@ describe('ListsService', () => {
           user_id: 'user-1',
           color_id: 'color-1',
           icon_id: 'icon-1',
+          picture_id: 'pic-1',
           color: defaultColor,
           icon: defaultIcon,
+          picture: defaultPicture,
           created_at: new Date('2026-01-01'),
           _count: { items: 0 },
           total_value: 0,
@@ -136,7 +154,12 @@ describe('ListsService', () => {
       );
 
       await expect(
-        service.create('user-1', { name: 'New List', color_id: 'color-1', icon_id: 'icon-1' }),
+        service.create('user-1', {
+          name: 'New List',
+          color_id: 'color-1',
+          icon_id: 'icon-1',
+          picture_id: 'pic-1',
+        }),
       ).rejects.toThrow(ForbiddenException);
       expect(repository.create).not.toHaveBeenCalled();
     });
@@ -148,11 +171,12 @@ describe('ListsService', () => {
         location: null,
         color_id: 'color-1',
         icon_id: 'icon-1',
+        picture_id: 'pic-1',
         user_id: 'user-1',
         created_at: new Date('2026-01-01'),
       });
 
-      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1' };
+      const dto = { name: 'New List', color_id: 'color-1', icon_id: 'icon-1', picture_id: 'pic-1' };
       const result = await service.create('user-1', dto);
 
       expect(repository.create).toHaveBeenCalledWith('user-1', dto, undefined);
@@ -162,6 +186,7 @@ describe('ListsService', () => {
         location: null,
         color_id: 'color-1',
         icon_id: 'icon-1',
+        picture_id: 'pic-1',
         item_count: 0,
         total_value: 0,
         created_at: new Date('2026-01-01'),
@@ -175,6 +200,7 @@ describe('ListsService', () => {
         location: '123 Main St',
         color_id: 'color-1',
         icon_id: 'icon-1',
+        picture_id: 'pic-1',
         user_id: 'user-1',
         created_at: new Date('2026-01-01'),
       });
@@ -184,6 +210,7 @@ describe('ListsService', () => {
         location: '123 Main St',
         color_id: 'color-1',
         icon_id: 'icon-1',
+        picture_id: 'pic-1',
       };
       const result = await service.create('user-1', dto);
 
@@ -201,6 +228,7 @@ describe('ListsService', () => {
         location: null,
         color_id: 'color-1',
         icon_id: 'icon-1',
+        picture_id: 'pic-1',
         created_at: new Date('2026-01-01'),
       });
 
@@ -218,6 +246,7 @@ describe('ListsService', () => {
         location: '456 Oak Ave',
         color_id: 'color-1',
         icon_id: 'icon-1',
+        picture_id: 'pic-1',
         created_at: new Date('2026-01-01'),
       });
 

--- a/src/modules/lists/lists.service.ts
+++ b/src/modules/lists/lists.service.ts
@@ -19,6 +19,10 @@ export class ListsService {
     return this.repository.findAllIcons();
   }
 
+  getPictures() {
+    return this.repository.findAllPictures();
+  }
+
   async getAll(userId: string) {
     const lists = await this.repository.findAllByUser(userId);
     return lists.map((list) => ({
@@ -27,6 +31,7 @@ export class ListsService {
       location: list.location ?? null,
       color: list.color,
       icon: list.icon,
+      picture: list.picture,
       item_count: list._count.items,
       total_value: list.total_value,
       created_at: list.created_at,
@@ -43,6 +48,7 @@ export class ListsService {
       location: list.location ?? null,
       color_id: list.color_id,
       icon_id: list.icon_id,
+      picture_id: list.picture_id,
       item_count: 0,
       total_value: 0,
       created_at: list.created_at,
@@ -60,6 +66,7 @@ export class ListsService {
       location: list.location ?? null,
       color_id: list.color_id,
       icon_id: list.icon_id,
+      picture_id: list.picture_id,
       created_at: list.created_at,
     };
   }

--- a/src/modules/lists/lists.service.ts
+++ b/src/modules/lists/lists.service.ts
@@ -11,12 +11,22 @@ export class ListsService {
     private readonly limits: LimitsService,
   ) {}
 
+  getColors() {
+    return this.repository.findAllColors();
+  }
+
+  getIcons() {
+    return this.repository.findAllIcons();
+  }
+
   async getAll(userId: string) {
     const lists = await this.repository.findAllByUser(userId);
     return lists.map((list) => ({
       id: list.id,
       name: list.name,
       location: list.location ?? null,
+      color: list.color,
+      icon: list.icon,
       item_count: list._count.items,
       total_value: list.total_value,
       created_at: list.created_at,
@@ -31,6 +41,8 @@ export class ListsService {
       id: list.id,
       name: list.name,
       location: list.location ?? null,
+      color_id: list.color_id,
+      icon_id: list.icon_id,
       item_count: 0,
       total_value: 0,
       created_at: list.created_at,
@@ -46,6 +58,8 @@ export class ListsService {
       id: list.id,
       name: list.name,
       location: list.location ?? null,
+      color_id: list.color_id,
+      icon_id: list.icon_id,
       created_at: list.created_at,
     };
   }


### PR DESCRIPTION
Closes #32

## What changed

- Added `list_colors` and `list_icons` DB tables with seeded preset values; custom SQL migration handles the multi-step NOT NULL column addition safely for existing rows
- `POST /lists` now requires `color_id` and `icon_id`; `PATCH /lists/:id` accepts them optionally
- New endpoints `GET /lists/colors` and `GET /lists/icons` return the available palettes ordered by `order` field
- `GET /lists` response now includes the full `color` and `icon` objects for each list

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (56 tests across lists and items specs)
- [ ] Run `prisma migrate deploy` against a DB and verify existing lists receive default color/icon
- [ ] `POST /lists` without `color_id` or `icon_id` returns 400
- [ ] `GET /lists/colors` and `GET /lists/icons` return ordered arrays