### PR TITLE
feat: include list name and color in item response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
       "user_defined_value": 0,
       "category": { "id": "uuid", "name": "string" } | null,
       "images": [],
-      "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
+      "list": { "name": "string", "color": "#rrggbb" },
       "created_at": "timestamp"
     }
   ],
@@ -125,7 +125,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
     "user_defined_value": "number | null",
     "category": { "id": "uuid", "name": "string" } | null,
     "images": [{ "url": "string", "is_main": true }],
-    "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
+    "list": { "name": "string", "color": "#rrggbb" },
     "created_at": "timestamp"
   }
 ]
@@ -152,7 +152,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "images": [
     { "url": "string", "is_main": true }
   ],  // empty array if no image uploaded
-  "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
+  "list": { "name": "string", "color": "#rrggbb" },
   "created_at": "timestamp"
 }
 
@@ -171,7 +171,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "images": [
     { "url": "string", "is_main": true }
   ],  // empty array if no image exists
-  "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
+  "list": { "name": "string", "color": "#rrggbb" },
   "created_at": "timestamp"
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,6 +92,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
       "user_defined_value": 0,
       "category": { "id": "uuid", "name": "string" } | null,
       "images": [],
+      "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
       "created_at": "timestamp"
     }
   ],
@@ -114,6 +115,21 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 | DELETE | /items/:id | Delete item |
 
 ```json
+// GET /items?search= — response 200
+[
+  {
+    "id": "uuid",
+    "name": "string",
+    "description": "string | null",
+    "quantity": 1,
+    "user_defined_value": "number | null",
+    "category": { "id": "uuid", "name": "string" } | null,
+    "images": [{ "url": "string", "is_main": true }],
+    "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
+    "created_at": "timestamp"
+  }
+]
+
 // POST /items — request (multipart/form-data)
 // Text fields:
 //   list_id: uuid (required)
@@ -136,6 +152,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "images": [
     { "url": "string", "is_main": true }
   ],  // empty array if no image uploaded
+  "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
   "created_at": "timestamp"
 }
 
@@ -154,6 +171,7 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
   "images": [
     { "url": "string", "is_main": true }
   ],  // empty array if no image exists
+  "list": { "name": "string", "color": { "hex_code": "#rrggbb", "name": "string" } },
   "created_at": "timestamp"
 }
 ```

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '../../generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -6,7 +6,7 @@ import { Prisma } from '../../generated/prisma/client';
 
 type ImagePayload = { url: string; storageKey: string; isMain: boolean };
 
-const includeImages = { category: true, images: true } as const;
+const includeImages = { category: true, images: true, list: { include: { color: true } } } as const;
 
 @Injectable()
 export class ItemsRepository {

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -17,6 +17,8 @@ const makeItem = (overrides: Partial<ReturnType<typeof baseItem>> = {}) => ({
   ...overrides,
 });
 
+const mockListColor = { hex_code: '#EF4444', name: 'Red' };
+
 function baseItem() {
   return {
     id: 'item-1',
@@ -35,6 +37,7 @@ function baseItem() {
       is_main: boolean;
       created_at: Date;
     }[],
+    list: { name: 'My List', color: mockListColor },
     created_at: new Date('2026-01-01'),
   };
 }
@@ -144,6 +147,7 @@ describe('ItemsService', () => {
         user_defined_value: null,
         category: null,
         images: [],
+        list: { name: 'My List', color: mockListColor },
         created_at: new Date('2026-01-01'),
       });
     });
@@ -368,6 +372,7 @@ describe('ItemsService', () => {
           user_defined_value: null,
           category: null,
           images: [],
+          list: { name: 'My List', color: mockListColor },
           created_at: createdAt,
         },
       ]);

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -17,8 +17,6 @@ const makeItem = (overrides: Partial<ReturnType<typeof baseItem>> = {}) => ({
   ...overrides,
 });
 
-const mockListColor = { hex_code: '#EF4444', name: 'Red' };
-
 function baseItem() {
   return {
     id: 'item-1',
@@ -37,7 +35,7 @@ function baseItem() {
       is_main: boolean;
       created_at: Date;
     }[],
-    list: { name: 'My List', color: mockListColor },
+    list: { name: 'My List', color: { hex_code: '#EF4444', name: 'Red' } },
     created_at: new Date('2026-01-01'),
   };
 }
@@ -147,7 +145,7 @@ describe('ItemsService', () => {
         user_defined_value: null,
         category: null,
         images: [],
-        list: { name: 'My List', color: mockListColor },
+        list: { name: 'My List', color: '#EF4444' },
         created_at: new Date('2026-01-01'),
       });
     });
@@ -372,7 +370,7 @@ describe('ItemsService', () => {
           user_defined_value: null,
           category: null,
           images: [],
-          list: { name: 'My List', color: mockListColor },
+          list: { name: 'My List', color: '#EF4444' },
           created_at: createdAt,
         },
       ]);

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -56,6 +56,10 @@ export class ItemsService {
       user_defined_value: item.user_defined_value != null ? Number(item.user_defined_value) : null,
       category: item.category ?? null,
       images,
+      list: {
+        name: item.list.name,
+        color: item.list.color,
+      },
       created_at: item.created_at,
     };
   }

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -58,7 +58,7 @@ export class ItemsService {
       images,
       list: {
         name: item.list.name,
-        color: item.list.color,
+        color: item.list.color?.hex_code ?? null,
       },
       created_at: item.created_at,
     };


### PR DESCRIPTION
Closes #34

## What changed

- Updated `includeImages` constant in `items.repository.ts` to also fetch `list` with its `color` via Prisma include
- Added `list: { name, color }` field to the object returned by `mapItem()` in `items.service.ts`
- Updated `items.service.spec.ts` to include the `list` field in `baseItem()` fixture and all exact `toEqual` assertions
- Updated `docs/api.md` to document the `list` field in all item response shapes (GET /items, GET /lists/:id/items, POST /items, PATCH /items/:id)

## Test plan

- [x] Build passes (pre-existing unrelated error in auth.repository.ts on main)
- [x] Lint passes
- [x] All 27 items service tests pass
- [ ] Manually verify GET /items and GET /lists/:id/items responses include `list.name` and `list.color`