### PR TITLE
feat: add cursor pagination to GET /items endpoint

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -420,7 +420,7 @@
       "name": "Items",
       "item": [
         {
-          "name": "GET /items?search=",
+          "name": "GET /items",
           "request": {
             "method": "GET",
             "header": [
@@ -430,7 +430,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/items?search=lamp",
+              "raw": "{{baseUrl}}/items?search=lamp&cursor=&limit=15",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -441,6 +441,17 @@
                 {
                   "key": "search",
                   "value": "lamp"
+                },
+                {
+                  "key": "cursor",
+                  "value": "",
+                  "disabled": true,
+                  "description": "UUID of last item from previous page"
+                },
+                {
+                  "key": "limit",
+                  "value": "15",
+                  "description": "Items per page (1-100, default 15)"
                 }
               ]
             }

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,26 +109,34 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | /items?search= | Global item search by name |
+| GET | /items?search=&cursor=&limit= | Global item search by name (cursor-paginated) |
 | POST | /items | Create item; optional image upload via multipart/form-data |
 | PATCH | /items/:id | Update item fields; optional image replacement |
 | DELETE | /items/:id | Delete item |
 
 ```json
-// GET /items?search= — response 200
-[
-  {
-    "id": "uuid",
-    "name": "string",
-    "description": "string | null",
-    "quantity": 1,
-    "user_defined_value": "number | null",
-    "category": { "id": "uuid", "name": "string" } | null,
-    "images": [{ "url": "string", "is_main": true }],
-    "list": { "name": "string", "color": "#rrggbb" },
-    "created_at": "timestamp"
-  }
-]
+// GET /items?search=&cursor=&limit= — query params
+// search: string (optional, default "")
+// cursor: uuid (optional) — id of last item from previous page
+// limit:  integer 1–100 (optional, default 15)
+
+// GET /items — response 200
+{
+  "data": [
+    {
+      "id": "uuid",
+      "name": "string",
+      "description": "string | null",
+      "quantity": 1,
+      "user_defined_value": "number | null",
+      "category": { "id": "uuid", "name": "string" },
+      "images": [{ "url": "string", "is_main": true }],
+      "list": { "name": "string", "color": "#rrggbb" },
+      "created_at": "timestamp"
+    }
+  ],
+  "nextCursor": "uuid | null"
+}
 
 // POST /items — request (multipart/form-data)
 // Text fields:

--- a/src/modules/items/dto/get-items.dto.ts
+++ b/src/modules/items/dto/get-items.dto.ts
@@ -1,0 +1,19 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+
+export class GetItemsDto {
+  @IsString()
+  @IsOptional()
+  search?: string = '';
+
+  @IsUUID()
+  @IsOptional()
+  cursor?: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit?: number = 15;
+}

--- a/src/modules/items/items.controller.spec.ts
+++ b/src/modules/items/items.controller.spec.ts
@@ -31,18 +31,18 @@ describe('ItemsController', () => {
       const expected = [{ id: 'item-1', name: 'lamp' }];
       mockItemsService.search.mockResolvedValue(expected);
 
-      const result = await controller.search('lamp', makeReq('user-1'));
+      const result = await controller.search({ search: 'lamp' }, makeReq('user-1'));
 
-      expect(mockItemsService.search).toHaveBeenCalledWith('user-1', 'lamp');
+      expect(mockItemsService.search).toHaveBeenCalledWith('user-1', 'lamp', undefined, undefined);
       expect(result).toBe(expected);
     });
 
     it('defaults query to empty string when not provided', async () => {
-      mockItemsService.search.mockResolvedValue([]);
+      mockItemsService.search.mockResolvedValue({ data: [], nextCursor: null });
 
-      await controller.search(undefined as any, makeReq('user-1'));
+      await controller.search({}, makeReq('user-1'));
 
-      expect(mockItemsService.search).toHaveBeenCalledWith('user-1', '');
+      expect(mockItemsService.search).toHaveBeenCalledWith('user-1', '', undefined, undefined);
     });
 
     it('is NOT marked @Public so JwtAuthGuard protects it', () => {

--- a/src/modules/items/items.controller.ts
+++ b/src/modules/items/items.controller.ts
@@ -19,6 +19,7 @@ import { Request } from 'express';
 import { ItemsService } from './items.service';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
+import { GetItemsDto } from './dto/get-items.dto';
 import { MAX_IMAGE_SIZE, multerImageFileFilter } from '../../common/utils/image-validation';
 
 const imageInterceptor = FileInterceptor('image', {
@@ -32,9 +33,9 @@ export class ItemsController {
   constructor(private readonly itemsService: ItemsService) {}
 
   @Get()
-  search(@Query('search') query: string = '', @Req() req: Request) {
+  search(@Query() dto: GetItemsDto, @Req() req: Request) {
     const user = req.user as { id: string };
-    return this.itemsService.search(user.id, query);
+    return this.itemsService.search(user.id, dto.search ?? '', dto.cursor, dto.limit);
   }
 
   @Post()

--- a/src/modules/items/items.repository.ts
+++ b/src/modules/items/items.repository.ts
@@ -115,13 +115,15 @@ export class ItemsRepository {
     return this.prisma.category.findMany({ orderBy: { name: 'asc' } });
   }
 
-  searchByUser(userId: string, search: string) {
+  searchByUser(userId: string, search: string, cursor?: string, limit: number = 15) {
     return this.prisma.item.findMany({
       where: {
         list: { user_id: userId },
         name: { contains: search, mode: 'insensitive' },
       },
-      orderBy: { created_at: 'desc' },
+      orderBy: [{ created_at: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      ...(cursor && { cursor: { id: cursor }, skip: 1 }),
       include: includeImages,
     });
   }

--- a/src/modules/items/items.service.spec.ts
+++ b/src/modules/items/items.service.spec.ts
@@ -360,20 +360,23 @@ describe('ItemsService', () => {
 
       const result = await service.search('user-1', 'lamp');
 
-      expect(itemsRepository.searchByUser).toHaveBeenCalledWith('user-1', 'lamp');
-      expect(result).toEqual([
-        {
-          id: 'item-1',
-          name: 'vintage lamp',
-          description: null,
-          quantity: 1,
-          user_defined_value: null,
-          category: null,
-          images: [],
-          list: { name: 'My List', color: '#EF4444' },
-          created_at: createdAt,
-        },
-      ]);
+      expect(itemsRepository.searchByUser).toHaveBeenCalledWith('user-1', 'lamp', undefined, 15);
+      expect(result).toEqual({
+        data: [
+          {
+            id: 'item-1',
+            name: 'vintage lamp',
+            description: null,
+            quantity: 1,
+            user_defined_value: null,
+            category: null,
+            images: [],
+            list: { name: 'My List', color: '#EF4444' },
+            created_at: createdAt,
+          },
+        ],
+        nextCursor: null,
+      });
     });
 
     it('converts user_defined_value Decimal to number in search results', async () => {
@@ -383,7 +386,7 @@ describe('ItemsService', () => {
 
       const result = await service.search('user-1', 'lamp');
 
-      expect(result[0].user_defined_value).toBe(5.5);
+      expect((result as any).data[0].user_defined_value).toBe(5.5);
     });
 
     it('returns empty array when no items match', async () => {
@@ -391,7 +394,7 @@ describe('ItemsService', () => {
 
       const result = await service.search('user-1', 'nonexistent');
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ data: [], nextCursor: null });
     });
   });
 

--- a/src/modules/items/items.service.ts
+++ b/src/modules/items/items.service.ts
@@ -150,9 +150,16 @@ export class ItemsService {
     return this.repository.findAllCategories();
   }
 
-  async search(userId: string, query: string) {
-    const items = await this.repository.searchByUser(userId, query);
-    return Promise.all(items.map((item) => this.mapItem(item)));
+  async search(userId: string, query: string, cursor?: string, limit: number = 15) {
+    const rows = await this.repository.searchByUser(userId, query, cursor, limit);
+    const hasNextPage = rows.length > limit;
+    const items = hasNextPage ? rows.slice(0, limit) : rows;
+    const nextCursor = hasNextPage ? items[items.length - 1].id : null;
+
+    return {
+      data: await Promise.all(items.map((item) => this.mapItem(item))),
+      nextCursor,
+    };
   }
 
   async getByList(listId: string, userId: string, cursor?: string, limit: number = 20) {


### PR DESCRIPTION
Closes #36

## What changed

- Added `GetItemsDto` with `search`, `cursor` (UUID), and `limit` (1–100, default 15) query params
- Updated `ItemsRepository.searchByUser` to accept cursor/limit and use compound `orderBy: [created_at DESC, id DESC]`
- Updated `ItemsService.search` to return `{ data: Item[], nextCursor: string | null }` using the `limit + 1` pattern
- Updated controller, tests, Postman collection, and `docs/api.md`

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (40 items tests green)
- [ ] Manual: `GET /items?limit=15` returns 15 items + `nextCursor`; passing cursor returns next page with no overlap