### PR TITLE
feat: dashboard and full-text search

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -705,6 +705,32 @@
           }
         }
       ]
+    },
+    {
+      "name": "Dashboard",
+      "item": [
+        {
+          "name": "GET /dashboard",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/dashboard",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,6 +227,24 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 ---
 
+## Dashboard <Badge type="tip" text="Implemented" />
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | /dashboard | Summary stats for the authenticated user |
+
+```json
+// GET /dashboard — response 200
+{
+  "list_count": 2,
+  "item_count": 3,
+  "total_value": 300
+}
+// total_value: sum of user_defined_value across all items; nulls treated as 0
+```
+
+---
+
 ## Monetization <Badge type="tip" text="Implemented" />
 
 Two tiers: **free** (default on registration) and **premium** (granted by a valid RevenueCat subscription).

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ hero:
 | Items CRUD | <Badge type="tip" text="Implemented" /> |
 | Image upload + storage | <Badge type="tip" text="Implemented" /> |
 | AI image analysis | <Badge type="tip" text="Implemented" /> |
-| Dashboard + search | <Badge type="warning" text="In Progress" /> |
+| Dashboard + search | <Badge type="tip" text="Implemented" /> |
 | Monetization tiers | <Badge type="tip" text="Implemented" /> |
 
 ## Cost Estimates by MAU Tier

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,11 +34,11 @@
 - [x] Return suggestions to client (`name`, `category`, `price_min`, `price_max`)
 - [x] Error response when AI fails (client falls back to manual entry)
 
-## Milestone 5 — Dashboard + Search <Badge type="warning" text="In Progress" />
+## Milestone 5 — Dashboard + Search <Badge type="tip" text="Implemented" />
 
 - [x] Per-list total value calculation
-- [ ] Global total value
-- [ ] Dashboard endpoint (list count, item count, total value)
+- [x] Global total value
+- [x] Dashboard endpoint (list count, item count, total value)
 - [x] Full-text search on item names
 
 ## Milestone 6 — Monetization <Badge type="warning" text="In Progress" />

--- a/prisma/migrations/20260424160825_add_item_name_index/migration.sql
+++ b/prisma/migrations/20260424160825_add_item_name_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "items_name_idx" ON "items"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model Item {
   images   ItemImage[]
 
   @@index([list_id])
+  @@index([name])
   @@map("items")
 }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { StorageModule } from './modules/storage/storage.module';
 import { AiModule } from './modules/ai/ai.module';
 import { TiersModule } from './modules/tiers/tiers.module';
 import { RevenueCatModule } from './modules/revenuecat/revenuecat.module';
+import { DashboardModule } from './modules/dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { RevenueCatModule } from './modules/revenuecat/revenuecat.module';
     StorageModule,
     AiModule,
     RevenueCatModule,
+    DashboardModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/src/modules/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,40 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+
+  const mockDashboardService = { getSummary: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [{ provide: DashboardService, useValue: mockDashboardService }],
+    }).compile();
+
+    controller = module.get<DashboardController>(DashboardController);
+    jest.clearAllMocks();
+  });
+
+  const makeReq = (id: string) => ({ user: { id } }) as any;
+
+  describe('summary', () => {
+    it('delegates to dashboardService.getSummary with userId from req.user.id', async () => {
+      const expected = { list_count: 2, item_count: 3, total_value: 300 };
+      mockDashboardService.getSummary.mockResolvedValue(expected);
+
+      const result = await controller.summary(makeReq('user-1'));
+
+      expect(mockDashboardService.getSummary).toHaveBeenCalledWith('user-1');
+      expect(result).toBe(expected);
+    });
+
+    it('is NOT marked @Public so JwtAuthGuard protects it', () => {
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, DashboardController.prototype.summary);
+      expect(isPublic).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  summary(@Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.dashboardService.getSummary(user.id);
+  }
+}

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { DashboardRepository } from './dashboard.repository';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService, DashboardRepository],
+})
+export class DashboardModule {}

--- a/src/modules/dashboard/dashboard.repository.ts
+++ b/src/modules/dashboard/dashboard.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class DashboardRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getSummary(userId: string) {
+    const [listCount, itemAgg] = await Promise.all([
+      this.prisma.list.count({ where: { user_id: userId } }),
+      this.prisma.item.aggregate({
+        where: { list: { user_id: userId } },
+        _count: { id: true },
+        _sum: { user_defined_value: true },
+      }),
+    ]);
+    return {
+      list_count: listCount,
+      item_count: itemAgg._count.id,
+      total_value: Number(itemAgg._sum.user_defined_value ?? 0),
+    };
+  }
+}

--- a/src/modules/dashboard/dashboard.service.spec.ts
+++ b/src/modules/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardService } from './dashboard.service';
+import { DashboardRepository } from './dashboard.repository';
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+  let repository: jest.Mocked<DashboardRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        {
+          provide: DashboardRepository,
+          useValue: { getSummary: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+    repository = module.get(DashboardRepository);
+  });
+
+  describe('getSummary', () => {
+    it('delegates to repository and returns result', async () => {
+      const summary = { list_count: 2, item_count: 3, total_value: 300 };
+      repository.getSummary.mockResolvedValue(summary);
+
+      const result = await service.getSummary('user-1');
+
+      expect(repository.getSummary).toHaveBeenCalledWith('user-1');
+      expect(result).toBe(summary);
+    });
+
+    it('returns zeros when user has no data', async () => {
+      const summary = { list_count: 0, item_count: 0, total_value: 0 };
+      repository.getSummary.mockResolvedValue(summary);
+
+      const result = await service.getSummary('user-1');
+
+      expect(result).toEqual({ list_count: 0, item_count: 0, total_value: 0 });
+    });
+  });
+});

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { DashboardRepository } from './dashboard.repository';
+
+@Injectable()
+export class DashboardService {
+  constructor(private readonly repository: DashboardRepository) {}
+
+  getSummary(userId: string) {
+    return this.repository.getSummary(userId);
+  }
+}


### PR DESCRIPTION
Closes #9

## What changed

- Added `GET /dashboard` endpoint returning `{ list_count, item_count, total_value }` for the authenticated user (JWT-protected)
- Created `DashboardModule` with controller, service, and repository following the established 3-layer pattern
- Added `@@index([name])` to `Item` model in Prisma schema for full-text search performance (non-breaking migration)
- Updated Postman collection, API docs, roadmap (Milestone 5 → Implemented), and feature status table

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (160 total, including 4 new dashboard specs)
- [ ] `GET /dashboard` returns correct counts and sum for a user with items
- [ ] `GET /dashboard` returns zeros for a user with no data
- [ ] Endpoint returns 401 without a valid JWT