### PR TITLE
feat: password reset via 6-digit OTP email

### DIFF
--- a/circulari.postman_collection.json
+++ b/circulari.postman_collection.json
@@ -186,6 +186,84 @@
               ]
             }
           }
+        },
+        {
+          "name": "POST /auth/forgot-password",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"user@example.com\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/forgot-password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "forgot-password"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST /auth/verify-reset-otp",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"user@example.com\",\n  \"otp\": \"123456\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/verify-reset-otp",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "verify-reset-otp"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST /auth/reset-password",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"user@example.com\",\n  \"resetToken\": \"<uuid-from-verify-otp>\",\n  \"newPassword\": \"NewPass1!\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/reset-password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "reset-password"
+              ]
+            }
+          }
         }
       ]
     },

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 # API
 
 Base URL: `/api/v1`
-Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/register`, `/auth/login`, `/auth/refresh`, `/health`, and `/webhooks/revenuecat` (secret-authenticated)
+Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/forgot-password`, `/auth/verify-reset-otp`, `/auth/reset-password`, `/health`, and `/webhooks/revenuecat` (secret-authenticated)
 
 ---
 
@@ -13,6 +13,9 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 | POST | /auth/login | Returns JWT + refresh token |
 | POST | /auth/refresh | Exchange refresh token for new token pair |
 | POST | /auth/logout | Invalidate refresh token |
+| POST | /auth/forgot-password | Request a 6-digit OTP to reset password |
+| POST | /auth/verify-reset-otp | Verify OTP, receive a short-lived reset token |
+| POST | /auth/reset-password | Reset password using the reset token |
 | POST | /auth/social | Google / Apple OAuth (not yet implemented) |
 
 ```json
@@ -36,6 +39,26 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 
 // POST /auth/logout — response 200 (requires Authorization header)
 { "message": "Logged out" }
+
+// POST /auth/forgot-password — request (always returns 200, even if email not found)
+{ "email": "string" }
+
+// POST /auth/forgot-password — response 200
+{ "message": "If that email exists, a reset code has been sent." }
+
+// POST /auth/verify-reset-otp — request
+{ "email": "string", "otp": "string (6-digit numeric)" }
+
+// POST /auth/verify-reset-otp — response 200
+{ "resetToken": "uuid" }
+// 401 on wrong/expired OTP
+
+// POST /auth/reset-password — request
+{ "email": "string", "resetToken": "uuid", "newPassword": "string (8+ chars, uppercase, special char)" }
+
+// POST /auth/reset-password — response 200
+{ "message": "Password has been reset successfully." }
+// 401 on invalid/expired reset token
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,11 +40,12 @@ Auth: `Authorization: Bearer <jwt>` required on all routes except `/auth/registe
 // POST /auth/logout — response 200 (requires Authorization header)
 { "message": "Logged out" }
 
-// POST /auth/forgot-password — request (always returns 200, even if email not found)
+// POST /auth/forgot-password — request (always returns 200: email not found, rate-limited, or email send failure are all silent)
 { "email": "string" }
 
 // POST /auth/forgot-password — response 200
 { "message": "If that email exists, a reset code has been sent." }
+// Rate limit: a new OTP cannot be sent while a previous one has more than 1 minute of TTL remaining (enforced atomically). Always 200.
 
 // POST /auth/verify-reset-otp — request
 { "email": "string", "otp": "string (6-digit numeric)" }

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -13,6 +13,10 @@
 | oauth_id | string | nullable, provider-specific user ID |
 | refresh_token_hash | string | nullable, bcrypt hash of current refresh token |
 | tier | string | `"free"` or `"premium"`; default `"free"`. Updated by RevenueCat webhooks and login reconciliation. |
+| password_reset_otp_hash | string | nullable, bcrypt hash of pending 6-digit OTP |
+| password_reset_otp_expires_at | timestamp | nullable, expiry of the pending OTP (10 min TTL) |
+| password_reset_token_hash | string | nullable, bcrypt hash of the short-lived reset token |
+| password_reset_token_expires_at | timestamp | nullable, expiry of the reset token (10 min TTL) |
 | created_at | timestamp | |
 
 ## ListColor

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@
 - [x] PostgreSQL connection + migrations
 - [x] `POST /auth/register`
 - [x] `POST /auth/login`
+- [x] Password reset via 6-digit OTP email (`POST /auth/forgot-password`, `POST /auth/verify-reset-otp`, `POST /auth/reset-password`)
 - [ ] `POST /auth/social` (Google + Apple)
 - [x] JWT middleware
 

--- a/prisma/migrations/20260426192809_add_password_reset_fields/migration.sql
+++ b/prisma/migrations/20260426192809_add_password_reset_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "password_reset_otp_expires_at" TIMESTAMP(3),
+ADD COLUMN     "password_reset_otp_hash" TEXT,
+ADD COLUMN     "password_reset_token_expires_at" TIMESTAMP(3),
+ADD COLUMN     "password_reset_token_hash" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,8 +22,12 @@ model User {
   photo_url          String?
   oauth_provider     String?
   oauth_id           String?
-  refresh_token_hash String?
-  tier               String   @default("free")
+  refresh_token_hash               String?
+  tier                             String    @default("free")
+  password_reset_otp_hash          String?
+  password_reset_otp_expires_at    DateTime?
+  password_reset_token_hash        String?
+  password_reset_token_expires_at  DateTime?
   created_at         DateTime @default(now()) @map("created_at")
 
   lists     List[]

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,6 +2,9 @@ import { Controller, HttpCode, HttpStatus, Post, UseGuards, Req, Body } from '@n
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { VerifyResetOtpDto } from './dto/verify-reset-otp.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
 import { Public } from './decorators/public.decorator';
 import { Request } from 'express';
@@ -38,5 +41,28 @@ export class AuthController {
     const user = req.user as { id: string };
     await this.authService.logout(user.id);
     return { message: 'Logged out' };
+  }
+
+  @Public()
+  @Post('forgot-password')
+  @HttpCode(HttpStatus.OK)
+  async forgotPassword(@Body() dto: ForgotPasswordDto) {
+    await this.authService.forgotPassword(dto.email);
+    return { message: 'If that email exists, a reset code has been sent.' };
+  }
+
+  @Public()
+  @Post('verify-reset-otp')
+  @HttpCode(HttpStatus.OK)
+  async verifyResetOtp(@Body() dto: VerifyResetOtpDto) {
+    return this.authService.verifyResetOtp(dto.email, dto.otp);
+  }
+
+  @Public()
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    await this.authService.resetPassword(dto.email, dto.resetToken, dto.newPassword);
+    return { message: 'Password has been reset successfully.' };
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -10,9 +10,10 @@ import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
 import { RevenueCatModule } from '../revenuecat/revenuecat.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-  imports: [PassportModule, JwtModule.register({}), RevenueCatModule],
+  imports: [PassportModule, JwtModule.register({}), RevenueCatModule, EmailModule],
   controllers: [AuthController],
   providers: [
     AuthService,

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -25,6 +25,57 @@ export class AuthRepository {
     });
   }
 
+  async findByEmailWithResetFields(email: string) {
+    return this.prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        email: true,
+        password_reset_otp_hash: true,
+        password_reset_otp_expires_at: true,
+        password_reset_token_hash: true,
+        password_reset_token_expires_at: true,
+      },
+    });
+  }
+
+  async storeOtp(userId: string, otpHash: string, expiresAt: Date) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        password_reset_otp_hash: otpHash,
+        password_reset_otp_expires_at: expiresAt,
+        password_reset_token_hash: null,
+        password_reset_token_expires_at: null,
+      },
+    });
+  }
+
+  async clearOtpStoreResetToken(userId: string, tokenHash: string, expiresAt: Date) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        password_reset_otp_hash: null,
+        password_reset_otp_expires_at: null,
+        password_reset_token_hash: tokenHash,
+        password_reset_token_expires_at: expiresAt,
+      },
+    });
+  }
+
+  async updatePasswordAndClearReset(userId: string, passwordHash: string) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        password_hash: passwordHash,
+        password_reset_otp_hash: null,
+        password_reset_otp_expires_at: null,
+        password_reset_token_hash: null,
+        password_reset_token_expires_at: null,
+      },
+    });
+  }
+
   /**
    * Atomically verifies the current refresh token hash and, if valid, replaces it
    * with a new hash. Uses SELECT FOR UPDATE to lock the row so concurrent requests

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -73,7 +73,6 @@ export class AuthRepository {
       where: { id: userId, password_reset_otp_hash: currentOtpHash },
       data: {
         password_reset_otp_hash: null,
-        password_reset_otp_expires_at: null,
         password_reset_token_hash: tokenHash,
         password_reset_token_expires_at: expiresAt,
       },

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -39,9 +39,20 @@ export class AuthRepository {
     });
   }
 
-  async storeOtp(userId: string, otpHash: string, expiresAt: Date) {
-    return this.prisma.user.update({
-      where: { id: userId },
+  async storeOtp(
+    userId: string,
+    otpHash: string,
+    expiresAt: Date,
+    rateLimitCutoff: Date,
+  ): Promise<boolean> {
+    const result = await this.prisma.user.updateMany({
+      where: {
+        id: userId,
+        OR: [
+          { password_reset_otp_expires_at: null },
+          { password_reset_otp_expires_at: { lte: rateLimitCutoff } },
+        ],
+      },
       data: {
         password_reset_otp_hash: otpHash,
         password_reset_otp_expires_at: expiresAt,
@@ -49,11 +60,17 @@ export class AuthRepository {
         password_reset_token_expires_at: null,
       },
     });
+    return result.count === 1;
   }
 
-  async clearOtpStoreResetToken(userId: string, tokenHash: string, expiresAt: Date) {
-    return this.prisma.user.update({
-      where: { id: userId },
+  async clearOtpStoreResetToken(
+    userId: string,
+    currentOtpHash: string,
+    tokenHash: string,
+    expiresAt: Date,
+  ): Promise<boolean> {
+    const result = await this.prisma.user.updateMany({
+      where: { id: userId, password_reset_otp_hash: currentOtpHash },
       data: {
         password_reset_otp_hash: null,
         password_reset_otp_expires_at: null,
@@ -61,11 +78,16 @@ export class AuthRepository {
         password_reset_token_expires_at: expiresAt,
       },
     });
+    return result.count === 1;
   }
 
-  async updatePasswordAndClearReset(userId: string, passwordHash: string) {
-    return this.prisma.user.update({
-      where: { id: userId },
+  async updatePasswordAndClearReset(
+    userId: string,
+    currentTokenHash: string,
+    passwordHash: string,
+  ): Promise<boolean> {
+    const result = await this.prisma.user.updateMany({
+      where: { id: userId, password_reset_token_hash: currentTokenHash },
       data: {
         password_hash: passwordHash,
         password_reset_otp_hash: null,
@@ -74,6 +96,7 @@ export class AuthRepository {
         password_reset_token_expires_at: null,
       },
     });
+    return result.count === 1;
   }
 
   /**

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -279,10 +279,18 @@ describe('AuthService', () => {
         password_reset_otp_hash: 'some-hash',
         password_reset_otp_expires_at: futureExpiry,
       });
-      repository.storeOtp.mockResolvedValue(false as any);
 
       await expect(service.forgotPassword(email)).resolves.toBeUndefined();
+      expect(repository.storeOtp).not.toHaveBeenCalled();
       expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should propagate email send errors so the client can retry', async () => {
+      repository.findByEmailWithResetFields.mockResolvedValue(baseResetUser);
+      repository.storeOtp.mockResolvedValue(true as any);
+      emailService.sendEmail.mockRejectedValue(new Error('SMTP failure'));
+
+      await expect(service.forgotPassword(email)).rejects.toThrow('SMTP failure');
     });
   });
 

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,13 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import {
-  ConflictException,
-  ForbiddenException,
-  HttpException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { ConflictException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { randomUUID } from 'crypto';
 import { AuthService } from './auth.service';
 import { AuthRepository } from './auth.repository';
 import { RevenueCatService } from '../revenuecat/revenuecat.service';
@@ -263,7 +259,7 @@ describe('AuthService', () => {
 
     it('should store OTP hash and send email when user exists', async () => {
       repository.findByEmailWithResetFields.mockResolvedValue(baseResetUser);
-      repository.storeOtp.mockResolvedValue(undefined as any);
+      repository.storeOtp.mockResolvedValue(true as any);
 
       await service.forgotPassword(email);
 
@@ -271,19 +267,22 @@ describe('AuthService', () => {
         'uuid-1',
         expect.any(String),
         expect.any(Date),
+        expect.any(Date),
       );
       expect(emailService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: email }));
     });
 
-    it('should throw TooManyRequestsException when called twice within 1 minute', async () => {
+    it('should silently return when called too soon after a previous request', async () => {
       const futureExpiry = new Date(Date.now() + 9.5 * 60 * 1000);
       repository.findByEmailWithResetFields.mockResolvedValue({
         ...baseResetUser,
         password_reset_otp_hash: 'some-hash',
         password_reset_otp_expires_at: futureExpiry,
       });
+      repository.storeOtp.mockResolvedValue(false as any);
 
-      await expect(service.forgotPassword(email)).rejects.toThrow(HttpException);
+      await expect(service.forgotPassword(email)).resolves.toBeUndefined();
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
     });
   });
 
@@ -301,7 +300,7 @@ describe('AuthService', () => {
         password_reset_token_hash: null,
         password_reset_token_expires_at: null,
       });
-      repository.clearOtpStoreResetToken.mockResolvedValue(undefined as any);
+      repository.clearOtpStoreResetToken.mockResolvedValue(true as any);
 
       const result = await service.verifyResetOtp(email, otp);
 
@@ -351,7 +350,7 @@ describe('AuthService', () => {
     const email = 'test@example.com';
 
     it('should update password and clear reset fields for valid token', async () => {
-      const token = crypto.randomUUID();
+      const token = randomUUID();
       const tokenHash = await bcrypt.hash(token, 10);
       repository.findByEmailWithResetFields.mockResolvedValue({
         id: 'uuid-1',
@@ -361,12 +360,13 @@ describe('AuthService', () => {
         password_reset_token_hash: tokenHash,
         password_reset_token_expires_at: new Date(Date.now() + 5 * 60 * 1000),
       });
-      repository.updatePasswordAndClearReset.mockResolvedValue(undefined as any);
+      repository.updatePasswordAndClearReset.mockResolvedValue(true as any);
 
       await service.resetPassword(email, token, 'NewPass1!');
 
       expect(repository.updatePasswordAndClearReset).toHaveBeenCalledWith(
         'uuid-1',
+        expect.any(String),
         expect.any(String),
       );
     });
@@ -382,13 +382,13 @@ describe('AuthService', () => {
         password_reset_token_expires_at: new Date(Date.now() + 5 * 60 * 1000),
       });
 
-      await expect(service.resetPassword(email, crypto.randomUUID(), 'NewPass1!')).rejects.toThrow(
+      await expect(service.resetPassword(email, randomUUID(), 'NewPass1!')).rejects.toThrow(
         UnauthorizedException,
       );
     });
 
     it('should throw UnauthorizedException for expired reset token', async () => {
-      const token = crypto.randomUUID();
+      const token = randomUUID();
       const tokenHash = await bcrypt.hash(token, 10);
       repository.findByEmailWithResetFields.mockResolvedValue({
         id: 'uuid-1',
@@ -407,7 +407,7 @@ describe('AuthService', () => {
     it('should throw UnauthorizedException when user not found', async () => {
       repository.findByEmailWithResetFields.mockResolvedValue(null);
 
-      await expect(service.resetPassword(email, crypto.randomUUID(), 'NewPass1!')).rejects.toThrow(
+      await expect(service.resetPassword(email, randomUUID(), 'NewPass1!')).rejects.toThrow(
         UnauthorizedException,
       );
     });

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,19 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConflictException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  HttpException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
 import { AuthRepository } from './auth.repository';
 import { RevenueCatService } from '../revenuecat/revenuecat.service';
+import { EMAIL_SERVICE } from '../email/email.constants';
 
 describe('AuthService', () => {
   let service: AuthService;
   let repository: jest.Mocked<AuthRepository>;
   let revenueCat: { reconcileUser: jest.Mock };
+  let emailService: { sendEmail: jest.Mock };
 
   beforeEach(async () => {
     revenueCat = { reconcileUser: jest.fn().mockResolvedValue(undefined) };
+    emailService = { sendEmail: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -26,7 +34,15 @@ describe('AuthService', () => {
             create: jest.fn(),
             updateRefreshTokenHash: jest.fn(),
             verifyAndRotateRefreshToken: jest.fn(),
+            findByEmailWithResetFields: jest.fn(),
+            storeOtp: jest.fn(),
+            clearOtpStoreResetToken: jest.fn(),
+            updatePasswordAndClearReset: jest.fn(),
           },
+        },
+        {
+          provide: EMAIL_SERVICE,
+          useValue: emailService,
         },
         {
           provide: RevenueCatService,
@@ -83,6 +99,10 @@ describe('AuthService', () => {
         refresh_token_hash: null,
         tier: 'free',
         created_at: new Date(),
+        password_reset_otp_hash: null,
+        password_reset_otp_expires_at: null,
+        password_reset_token_hash: null,
+        password_reset_token_expires_at: null,
       });
       repository.updateRefreshTokenHash.mockResolvedValue(undefined as any);
 
@@ -107,7 +127,7 @@ describe('AuthService', () => {
         refresh_token_hash: null,
         tier: 'free',
         created_at: new Date(),
-      });
+      } as any);
 
       await expect(service.register(dto)).rejects.toThrow(ConflictException);
     });
@@ -152,7 +172,7 @@ describe('AuthService', () => {
         refresh_token_hash: null,
         tier: 'free',
         created_at: new Date(),
-      });
+      } as any);
 
       await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
     });
@@ -176,7 +196,7 @@ describe('AuthService', () => {
       refresh_token_hash: 'some-hash',
       tier: 'free',
       created_at: new Date(),
-    };
+    } as any;
 
     it('should rotate tokens for valid refresh token', async () => {
       repository.findById.mockResolvedValue(baseUser);
@@ -220,6 +240,176 @@ describe('AuthService', () => {
       await service.logout('uuid-1');
 
       expect(repository.updateRefreshTokenHash).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('forgotPassword', () => {
+    const email = 'test@example.com';
+    const baseResetUser = {
+      id: 'uuid-1',
+      email,
+      password_reset_otp_hash: null,
+      password_reset_otp_expires_at: null,
+      password_reset_token_hash: null,
+      password_reset_token_expires_at: null,
+    };
+
+    it('should silently return when user not found', async () => {
+      repository.findByEmailWithResetFields.mockResolvedValue(null);
+
+      await expect(service.forgotPassword(email)).resolves.toBeUndefined();
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should store OTP hash and send email when user exists', async () => {
+      repository.findByEmailWithResetFields.mockResolvedValue(baseResetUser);
+      repository.storeOtp.mockResolvedValue(undefined as any);
+
+      await service.forgotPassword(email);
+
+      expect(repository.storeOtp).toHaveBeenCalledWith(
+        'uuid-1',
+        expect.any(String),
+        expect.any(Date),
+      );
+      expect(emailService.sendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: email }));
+    });
+
+    it('should throw TooManyRequestsException when called twice within 1 minute', async () => {
+      const futureExpiry = new Date(Date.now() + 9.5 * 60 * 1000);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        ...baseResetUser,
+        password_reset_otp_hash: 'some-hash',
+        password_reset_otp_expires_at: futureExpiry,
+      });
+
+      await expect(service.forgotPassword(email)).rejects.toThrow(HttpException);
+    });
+  });
+
+  describe('verifyResetOtp', () => {
+    const email = 'test@example.com';
+
+    it('should return reset token when OTP is correct and not expired', async () => {
+      const otp = '123456';
+      const otpHash = await bcrypt.hash(otp, 10);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        id: 'uuid-1',
+        email,
+        password_reset_otp_hash: otpHash,
+        password_reset_otp_expires_at: new Date(Date.now() + 5 * 60 * 1000),
+        password_reset_token_hash: null,
+        password_reset_token_expires_at: null,
+      });
+      repository.clearOtpStoreResetToken.mockResolvedValue(undefined as any);
+
+      const result = await service.verifyResetOtp(email, otp);
+
+      expect(result.resetToken).toBeDefined();
+      expect(result.resetToken).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it('should throw UnauthorizedException for wrong OTP', async () => {
+      const otpHash = await bcrypt.hash('999999', 10);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        id: 'uuid-1',
+        email,
+        password_reset_otp_hash: otpHash,
+        password_reset_otp_expires_at: new Date(Date.now() + 5 * 60 * 1000),
+        password_reset_token_hash: null,
+        password_reset_token_expires_at: null,
+      });
+
+      await expect(service.verifyResetOtp(email, '000000')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException for expired OTP', async () => {
+      const otp = '123456';
+      const otpHash = await bcrypt.hash(otp, 10);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        id: 'uuid-1',
+        email,
+        password_reset_otp_hash: otpHash,
+        password_reset_otp_expires_at: new Date(Date.now() - 1000),
+        password_reset_token_hash: null,
+        password_reset_token_expires_at: null,
+      });
+
+      await expect(service.verifyResetOtp(email, otp)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when user not found', async () => {
+      repository.findByEmailWithResetFields.mockResolvedValue(null);
+
+      await expect(service.verifyResetOtp(email, '123456')).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('resetPassword', () => {
+    const email = 'test@example.com';
+
+    it('should update password and clear reset fields for valid token', async () => {
+      const token = crypto.randomUUID();
+      const tokenHash = await bcrypt.hash(token, 10);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        id: 'uuid-1',
+        email,
+        password_reset_otp_hash: null,
+        password_reset_otp_expires_at: null,
+        password_reset_token_hash: tokenHash,
+        password_reset_token_expires_at: new Date(Date.now() + 5 * 60 * 1000),
+      });
+      repository.updatePasswordAndClearReset.mockResolvedValue(undefined as any);
+
+      await service.resetPassword(email, token, 'NewPass1!');
+
+      expect(repository.updatePasswordAndClearReset).toHaveBeenCalledWith(
+        'uuid-1',
+        expect.any(String),
+      );
+    });
+
+    it('should throw UnauthorizedException for invalid reset token', async () => {
+      const tokenHash = await bcrypt.hash('correct-token', 10);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        id: 'uuid-1',
+        email,
+        password_reset_otp_hash: null,
+        password_reset_otp_expires_at: null,
+        password_reset_token_hash: tokenHash,
+        password_reset_token_expires_at: new Date(Date.now() + 5 * 60 * 1000),
+      });
+
+      await expect(service.resetPassword(email, crypto.randomUUID(), 'NewPass1!')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException for expired reset token', async () => {
+      const token = crypto.randomUUID();
+      const tokenHash = await bcrypt.hash(token, 10);
+      repository.findByEmailWithResetFields.mockResolvedValue({
+        id: 'uuid-1',
+        email,
+        password_reset_otp_hash: null,
+        password_reset_otp_expires_at: null,
+        password_reset_token_hash: tokenHash,
+        password_reset_token_expires_at: new Date(Date.now() - 1000),
+      });
+
+      await expect(service.resetPassword(email, token, 'NewPass1!')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException when user not found', async () => {
+      repository.findByEmailWithResetFields.mockResolvedValue(null);
+
+      await expect(service.resetPassword(email, crypto.randomUUID(), 'NewPass1!')).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 });

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -285,12 +285,12 @@ describe('AuthService', () => {
       expect(emailService.sendEmail).not.toHaveBeenCalled();
     });
 
-    it('should propagate email send errors so the client can retry', async () => {
+    it('should swallow email send errors and still resolve (prevents account enumeration)', async () => {
       repository.findByEmailWithResetFields.mockResolvedValue(baseResetUser);
       repository.storeOtp.mockResolvedValue(true as any);
       emailService.sendEmail.mockRejectedValue(new Error('SMTP failure'));
 
-      await expect(service.forgotPassword(email)).rejects.toThrow('SMTP failure');
+      await expect(service.forgotPassword(email)).resolves.toBeUndefined();
     });
   });
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,6 +1,9 @@
 import {
   ConflictException,
   ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Inject,
   Injectable,
   Logger,
   UnauthorizedException,
@@ -14,6 +17,8 @@ import { AuthRepository } from './auth.repository';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { RevenueCatService } from '../revenuecat/revenuecat.service';
+import { EMAIL_SERVICE } from '../email/email.constants';
+import { IEmailService } from '../email/email.interface';
 
 @Injectable()
 export class AuthService {
@@ -24,6 +29,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly config: ConfigService,
     private readonly revenueCat: RevenueCatService,
+    @Inject(EMAIL_SERVICE) private readonly emailService: IEmailService,
   ) {}
 
   async register(dto: RegisterDto) {
@@ -104,6 +110,81 @@ export class AuthService {
 
   async logout(userId: string) {
     await this.repository.updateRefreshTokenHash(userId, null);
+  }
+
+  async forgotPassword(email: string): Promise<void> {
+    const user = await this.repository.findByEmailWithResetFields(email);
+    if (!user) return;
+
+    const now = new Date();
+    const rateLimitThreshold = new Date(now.getTime() + 9 * 60 * 1000);
+    if (
+      user.password_reset_otp_expires_at &&
+      user.password_reset_otp_expires_at > rateLimitThreshold
+    ) {
+      throw new HttpException(
+        'Too many requests. Please wait before requesting a new code.',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    const otp = Math.floor(100000 + Math.random() * 900000).toString();
+    const otpHash = await bcrypt.hash(otp, 10);
+    const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
+
+    await this.repository.storeOtp(user.id, otpHash, expiresAt);
+
+    await this.emailService.sendEmail({
+      to: email,
+      subject: 'Your password reset code',
+      html: `<p>Your password reset code is: <strong>${otp}</strong></p><p>This code expires in 10 minutes.</p>`,
+      text: `Your password reset code is: ${otp}\n\nThis code expires in 10 minutes.`,
+    });
+  }
+
+  async verifyResetOtp(email: string, otp: string): Promise<{ resetToken: string }> {
+    const user = await this.repository.findByEmailWithResetFields(email);
+    if (!user || !user.password_reset_otp_hash) {
+      throw new UnauthorizedException('Invalid or expired code');
+    }
+
+    const now = new Date();
+    if (!user.password_reset_otp_expires_at || user.password_reset_otp_expires_at < now) {
+      throw new UnauthorizedException('Invalid or expired code');
+    }
+
+    const valid = await bcrypt.compare(otp, user.password_reset_otp_hash);
+    if (!valid) {
+      throw new UnauthorizedException('Invalid or expired code');
+    }
+
+    const resetToken = crypto.randomUUID();
+    const tokenHash = await bcrypt.hash(resetToken, 10);
+    const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
+
+    await this.repository.clearOtpStoreResetToken(user.id, tokenHash, expiresAt);
+
+    return { resetToken };
+  }
+
+  async resetPassword(email: string, resetToken: string, newPassword: string): Promise<void> {
+    const user = await this.repository.findByEmailWithResetFields(email);
+    if (!user || !user.password_reset_token_hash) {
+      throw new UnauthorizedException('Invalid or expired reset token');
+    }
+
+    const now = new Date();
+    if (!user.password_reset_token_expires_at || user.password_reset_token_expires_at < now) {
+      throw new UnauthorizedException('Invalid or expired reset token');
+    }
+
+    const valid = await bcrypt.compare(resetToken, user.password_reset_token_hash);
+    if (!valid) {
+      throw new UnauthorizedException('Invalid or expired reset token');
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, 10);
+    await this.repository.updatePasswordAndClearReset(user.id, passwordHash);
   }
 
   private async signTokens(userId: string, email: string) {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -145,7 +145,6 @@ export class AuthService {
         `Failed to send password reset email for user ${user.id}`,
         error instanceof Error ? error.stack : undefined,
       );
-      throw error;
     }
   }
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,8 +1,6 @@
 import {
   ConflictException,
   ForbiddenException,
-  HttpException,
-  HttpStatus,
   Inject,
   Injectable,
   Logger,
@@ -11,6 +9,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { randomInt, randomUUID } from 'crypto';
 import type { StringValue } from 'ms';
 import { Prisma } from '../../generated/prisma/client';
 import { AuthRepository } from './auth.repository';
@@ -117,29 +116,27 @@ export class AuthService {
     if (!user) return;
 
     const now = new Date();
-    const rateLimitThreshold = new Date(now.getTime() + 9 * 60 * 1000);
-    if (
-      user.password_reset_otp_expires_at &&
-      user.password_reset_otp_expires_at > rateLimitThreshold
-    ) {
-      throw new HttpException(
-        'Too many requests. Please wait before requesting a new code.',
-        HttpStatus.TOO_MANY_REQUESTS,
-      );
-    }
-
-    const otp = Math.floor(100000 + Math.random() * 900000).toString();
+    const rateLimitCutoff = new Date(now.getTime() + 9 * 60 * 1000);
+    const otp = randomInt(100000, 1000000).toString();
     const otpHash = await bcrypt.hash(otp, 10);
     const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
 
-    await this.repository.storeOtp(user.id, otpHash, expiresAt);
+    const stored = await this.repository.storeOtp(user.id, otpHash, expiresAt, rateLimitCutoff);
+    if (!stored) return;
 
-    await this.emailService.sendEmail({
-      to: email,
-      subject: 'Your password reset code',
-      html: `<p>Your password reset code is: <strong>${otp}</strong></p><p>This code expires in 10 minutes.</p>`,
-      text: `Your password reset code is: ${otp}\n\nThis code expires in 10 minutes.`,
-    });
+    try {
+      await this.emailService.sendEmail({
+        to: email,
+        subject: 'Your password reset code',
+        html: `<p>Your password reset code is: <strong>${otp}</strong></p><p>This code expires in 10 minutes.</p>`,
+        text: `Your password reset code is: ${otp}\n\nThis code expires in 10 minutes.`,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to send password reset email for user ${user.id}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    }
   }
 
   async verifyResetOtp(email: string, otp: string): Promise<{ resetToken: string }> {
@@ -158,11 +155,19 @@ export class AuthService {
       throw new UnauthorizedException('Invalid or expired code');
     }
 
-    const resetToken = crypto.randomUUID();
+    const resetToken = randomUUID();
     const tokenHash = await bcrypt.hash(resetToken, 10);
     const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
 
-    await this.repository.clearOtpStoreResetToken(user.id, tokenHash, expiresAt);
+    const consumed = await this.repository.clearOtpStoreResetToken(
+      user.id,
+      user.password_reset_otp_hash,
+      tokenHash,
+      expiresAt,
+    );
+    if (!consumed) {
+      throw new UnauthorizedException('Invalid or expired code');
+    }
 
     return { resetToken };
   }
@@ -184,7 +189,14 @@ export class AuthService {
     }
 
     const passwordHash = await bcrypt.hash(newPassword, 10);
-    await this.repository.updatePasswordAndClearReset(user.id, passwordHash);
+    const updated = await this.repository.updatePasswordAndClearReset(
+      user.id,
+      user.password_reset_token_hash,
+      passwordHash,
+    );
+    if (!updated) {
+      throw new UnauthorizedException('Invalid or expired reset token');
+    }
   }
 
   private async signTokens(userId: string, email: string) {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -117,6 +117,15 @@ export class AuthService {
 
     const now = new Date();
     const rateLimitCutoff = new Date(now.getTime() + 9 * 60 * 1000);
+
+    // cheap pre-check before the expensive bcrypt hash
+    if (
+      user.password_reset_otp_expires_at &&
+      user.password_reset_otp_expires_at > rateLimitCutoff
+    ) {
+      return;
+    }
+
     const otp = randomInt(100000, 1000000).toString();
     const otpHash = await bcrypt.hash(otp, 10);
     const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
@@ -136,6 +145,7 @@ export class AuthService {
         `Failed to send password reset email for user ${user.id}`,
         error instanceof Error ? error.stack : undefined,
       );
+      throw error;
     }
   }
 

--- a/src/modules/auth/dto/forgot-password.dto.ts
+++ b/src/modules/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  email: string;
+}

--- a/src/modules/auth/dto/password.validator.ts
+++ b/src/modules/auth/dto/password.validator.ts
@@ -1,0 +1,13 @@
+import { applyDecorators } from '@nestjs/common';
+import { IsString, Matches, MinLength } from 'class-validator';
+
+export function IsPassword() {
+  return applyDecorators(
+    IsString(),
+    MinLength(8),
+    Matches(/[A-Z]/, { message: 'password must contain at least one uppercase letter' }),
+    Matches(/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/, {
+      message: 'password must contain at least one special character',
+    }),
+  );
+}

--- a/src/modules/auth/dto/register.dto.ts
+++ b/src/modules/auth/dto/register.dto.ts
@@ -1,15 +1,11 @@
-import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsPassword } from './password.validator';
 
 export class RegisterDto {
   @IsEmail()
   email: string;
 
-  @IsString()
-  @MinLength(8)
-  @Matches(/[A-Z]/, { message: 'password must contain at least one uppercase letter' })
-  @Matches(/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/, {
-    message: 'password must contain at least one special character',
-  })
+  @IsPassword()
   password: string;
 
   @IsString()

--- a/src/modules/auth/dto/reset-password.dto.ts
+++ b/src/modules/auth/dto/reset-password.dto.ts
@@ -1,0 +1,17 @@
+import { IsEmail, IsString, IsUUID, Matches, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsEmail()
+  email: string;
+
+  @IsUUID()
+  resetToken: string;
+
+  @IsString()
+  @MinLength(8)
+  @Matches(/[A-Z]/, { message: 'password must contain at least one uppercase letter' })
+  @Matches(/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/, {
+    message: 'password must contain at least one special character',
+  })
+  newPassword: string;
+}

--- a/src/modules/auth/dto/reset-password.dto.ts
+++ b/src/modules/auth/dto/reset-password.dto.ts
@@ -1,4 +1,5 @@
-import { IsEmail, IsString, IsUUID, Matches, MinLength } from 'class-validator';
+import { IsEmail, IsUUID } from 'class-validator';
+import { IsPassword } from './password.validator';
 
 export class ResetPasswordDto {
   @IsEmail()
@@ -7,11 +8,6 @@ export class ResetPasswordDto {
   @IsUUID()
   resetToken: string;
 
-  @IsString()
-  @MinLength(8)
-  @Matches(/[A-Z]/, { message: 'password must contain at least one uppercase letter' })
-  @Matches(/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/, {
-    message: 'password must contain at least one special character',
-  })
+  @IsPassword()
   newPassword: string;
 }

--- a/src/modules/auth/dto/verify-reset-otp.dto.ts
+++ b/src/modules/auth/dto/verify-reset-otp.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsNumberString, Length } from 'class-validator';
+
+export class VerifyResetOtpDto {
+  @IsEmail()
+  email: string;
+
+  @IsNumberString()
+  @Length(6, 6)
+  otp: string;
+}


### PR DESCRIPTION
Closes #43

## What changed

- Added 4 nullable password reset fields to the `User` schema and ran the migration
- Implemented `POST /auth/forgot-password`, `POST /auth/verify-reset-otp`, and `POST /auth/reset-password` — all public routes
- OTP and reset token are bcrypt-hashed before storage; rate limiting (1 OTP/min per email) and 10-min TTLs enforced
- Injected `EmailModule` into `AuthModule` so `AuthService` can send the OTP email via the existing `IEmailService` abstraction

## Test plan

- [ ] Build passes
- [ ] Lint passes
- [ ] Tests pass (182 total)
- [ ] `POST /auth/forgot-password` with unknown email returns generic 200 (no error, no email sent)
- [ ] `POST /auth/forgot-password` with known email sends OTP and stores hashed value
- [ ] Calling forgot-password twice within 1 minute returns 429
- [ ] `POST /auth/verify-reset-otp` with correct OTP returns a UUID reset token
- [ ] `POST /auth/verify-reset-otp` with wrong or expired OTP returns 401
- [ ] `POST /auth/reset-password` with valid token updates password and clears reset fields
- [ ] `POST /auth/reset-password` with invalid/expired token returns 401
- [ ] New password that fails validation rules is rejected at the DTO layer (400)