### PR TITLE
feat: add Resend email provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,13 @@ STORAGE_REGION=us-east-1
 # STORAGE_PUBLIC_URL=http://localhost:9000/circulari
 
 # Email
-EMAIL_PROVIDER=stalwart   # stalwart | mock
+EMAIL_PROVIDER=stalwart   # stalwart | resend | mock
 EMAIL_FROM=no-reply@example.com
 STALWART_SMTP_HOST=
 STALWART_SMTP_PORT=587
 STALWART_SMTP_USER=
 STALWART_SMTP_PASS=
+RESEND_API_KEY=
 
 # RevenueCat (monetization)
 REVENUECAT_WEBHOOK_SECRET=

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -42,12 +42,13 @@ Recommended: `docker-compose.yml` with services for `api`, `postgres`, `nginx`.
 | `FREE_MAX_LISTS` | Free-tier cap on total lists per user (default 3) |
 | `FREE_MAX_ITEMS` | Free-tier cap on total items per user (default 50) |
 | `FREE_MAX_AI_CALLS_PER_MONTH` | Free-tier cap on `/ai/analyze` calls per calendar month (default 10) |
-| `EMAIL_PROVIDER` | Email transport: `stalwart` or `mock` |
+| `EMAIL_PROVIDER` | Email transport: `stalwart`, `resend`, or `mock` |
 | `EMAIL_FROM` | Sender address (e.g. `no-reply@example.com`) |
 | `STALWART_SMTP_HOST` | SMTP hostname for Stalwart provider |
 | `STALWART_SMTP_PORT` | SMTP port (typically `587`; required for Stalwart provider) |
 | `STALWART_SMTP_USER` | SMTP username |
 | `STALWART_SMTP_PASS` | SMTP password |
+| `RESEND_API_KEY` | API key for Resend provider (required when `EMAIL_PROVIDER=resend`) |
 
 ## Backup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@nestjs/platform-express": "^11.0.0",
         "@nestjs/terminus": "^11.0.0",
         "@prisma/client": "^6.0.0",
-        "@types/nodemailer": "^8.0.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -26,6 +25,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
+        "resend": "^6.12.2",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
@@ -37,6 +37,7 @@
         "@types/jest": "^29.5.14",
         "@types/multer": "^2.1.0",
         "@types/node": "^22.0.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/passport-jwt": "^4.0.1",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
@@ -5128,6 +5129,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5462,6 +5469,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
       "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8482,6 +8490,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -11602,6 +11616,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -11957,6 +11977,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -12611,6 +12652,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -12789,6 +12840,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/symbol-observable": {
@@ -13577,6 +13638,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
+    "resend": "^6.12.2",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
@@ -47,11 +48,11 @@
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.0",
     "@types/bcrypt": "^6.0.0",
-    "@types/nodemailer": "^8.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.0.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/passport-jwt": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/src/modules/email/email.module.ts
+++ b/src/modules/email/email.module.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { EMAIL_SERVICE } from './email.constants';
 import { StalwartEmailService } from './providers/stalwart-email.service';
 import { MockEmailService } from './providers/mock-email.service';
+import { ResendEmailService } from './providers/resend-email.service';
 import { EmailController } from './email.controller';
 
 @Module({
@@ -18,8 +19,12 @@ import { EmailController } from './email.controller';
             return new MockEmailService();
           case 'stalwart':
             return new StalwartEmailService(config);
+          case 'resend':
+            return new ResendEmailService(config);
           default:
-            throw new Error(`Unknown EMAIL_PROVIDER "${provider}". Valid values: stalwart, mock`);
+            throw new Error(
+              `Unknown EMAIL_PROVIDER "${provider}". Valid values: stalwart, resend, mock`,
+            );
         }
       },
     },

--- a/src/modules/email/email.service.spec.ts
+++ b/src/modules/email/email.service.spec.ts
@@ -1,6 +1,14 @@
 import { ConfigService } from '@nestjs/config';
 import { StalwartEmailService } from './providers/stalwart-email.service';
 import { MockEmailService } from './providers/mock-email.service';
+import { ResendEmailService } from './providers/resend-email.service';
+
+const mockResendSend = jest.fn();
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send: mockResendSend },
+  })),
+}));
 
 jest.mock('nodemailer', () => {
   const mockSendMail = jest.fn().mockResolvedValue({});
@@ -65,6 +73,59 @@ describe('StalwartEmailService', () => {
 
   it('throws on missing required config', () => {
     expect(() => new StalwartEmailService(mockConfig({}))).toThrow();
+  });
+});
+
+describe('ResendEmailService', () => {
+  const baseConfig = {
+    EMAIL_FROM: 'no-reply@example.com',
+    RESEND_API_KEY: 're_test_key',
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls resend.emails.send with correct params', async () => {
+    mockResendSend.mockResolvedValue({ data: { id: 'msg_123' }, error: null });
+    const service = new ResendEmailService(mockConfig(baseConfig));
+
+    await service.sendEmail({ to: 'user@test.com', subject: 'Hello', html: '<p>Hi</p>' });
+
+    expect(mockResendSend).toHaveBeenCalledWith({
+      from: 'no-reply@example.com',
+      to: 'user@test.com',
+      subject: 'Hello',
+      html: '<p>Hi</p>',
+      text: undefined,
+    });
+  });
+
+  it('includes text when provided', async () => {
+    mockResendSend.mockResolvedValue({ data: { id: 'msg_123' }, error: null });
+    const service = new ResendEmailService(mockConfig(baseConfig));
+
+    await service.sendEmail({
+      to: 'user@test.com',
+      subject: 'Hello',
+      html: '<p>Hi</p>',
+      text: 'Hi',
+    });
+
+    expect(mockResendSend).toHaveBeenCalledWith(expect.objectContaining({ text: 'Hi' }));
+  });
+
+  it('throws when resend returns an error', async () => {
+    mockResendSend.mockResolvedValue({ data: null, error: { message: 'Invalid API key' } });
+    const service = new ResendEmailService(mockConfig(baseConfig));
+
+    await expect(
+      service.sendEmail({ to: 'user@test.com', subject: 'Hello', html: '<p>Hi</p>' }),
+    ).rejects.toThrow('Resend error: Invalid API key');
+  });
+
+  it('throws on missing RESEND_API_KEY', () => {
+    expect(
+      () => new ResendEmailService(mockConfig({ EMAIL_FROM: 'no-reply@example.com' })),
+    ).toThrow();
   });
 });
 

--- a/src/modules/email/providers/resend-email.service.ts
+++ b/src/modules/email/providers/resend-email.service.ts
@@ -1,0 +1,28 @@
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+import { IEmailService, SendEmailParams } from '../email.interface';
+
+export class ResendEmailService implements IEmailService {
+  private readonly client: Resend;
+  private readonly from: string;
+
+  constructor(private readonly config: ConfigService) {
+    const apiKey = config.getOrThrow<string>('RESEND_API_KEY');
+    this.from = config.getOrThrow<string>('EMAIL_FROM');
+    this.client = new Resend(apiKey);
+  }
+
+  async sendEmail(params: SendEmailParams): Promise<void> {
+    const { error } = await this.client.emails.send({
+      from: this.from,
+      to: params.to,
+      subject: params.subject,
+      html: params.html,
+      text: params.text,
+    });
+
+    if (error) {
+      throw new Error(`Resend error: ${error.message}`);
+    }
+  }
+}

--- a/src/modules/email/providers/resend-email.service.ts
+++ b/src/modules/email/providers/resend-email.service.ts
@@ -22,7 +22,7 @@ export class ResendEmailService implements IEmailService {
     });
 
     if (error) {
-      throw new Error(`Resend error: ${error.message}`);
+      throw new Error(`Resend error: ${error.message}`, { cause: error });
     }
   }
 }


### PR DESCRIPTION
Closes #45

## What changed

- Added `ResendEmailService` implementing `IEmailService` via the Resend SDK
- Registered `resend` case in the `email.module.ts` factory; updated the unknown-provider error message to list all three valid values
- Added `RESEND_API_KEY` to `.env.example` and `docs/infra.md`; updated `EMAIL_PROVIDER` description to include `resend`
- Added 4 unit tests for `ResendEmailService` (happy path, text field, API error propagation, missing API key)

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (10/10 in `email.service.spec.ts`)
- [ ] Set `EMAIL_PROVIDER=resend` + valid `RESEND_API_KEY` and trigger a password-reset OTP to verify end-to-end delivery